### PR TITLE
feat(mobile): EAS build/submit config + release scaffolding (#123)

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,82 @@
+name: EAS Build
+
+# Manual only: kick off cloud builds from the Actions tab. Keeping this off the
+# PR/push path avoids burning EAS build minutes on every mobile change.
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Platform to build
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - ios
+          - android
+      profile:
+        description: EAS build profile (see apps/mobile/eas.json)
+        type: choice
+        required: true
+        default: preview
+        options:
+          - development
+          - preview
+          - production
+      submit:
+        description: Submit to the stores after a successful production build
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: eas-build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: ${{ github.workspace }}
+
+      # --auto-submit (production only) submits straight after the build using the
+      # matching submit profile and implies --wait, so there is no race with a
+      # separate submit step. Plain builds use --no-wait and finish in EAS cloud.
+      - name: Build
+        run: |
+          if [ "${{ github.event.inputs.submit }}" = "true" ] && [ "${{ github.event.inputs.profile }}" = "production" ]; then
+            eas build \
+              --non-interactive \
+              --platform ${{ github.event.inputs.platform }} \
+              --profile production \
+              --auto-submit
+          else
+            eas build \
+              --non-interactive \
+              --no-wait \
+              --platform ${{ github.event.inputs.platform }} \
+              --profile ${{ github.event.inputs.profile }}
+          fi

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -17,5 +17,8 @@ src/uniwind-env.d.ts
 # Env
 .env*.local
 
+# EAS store-submission credentials — never commit
+google-service-account.json
+
 # Misc
 *.log

--- a/apps/mobile/RELEASE.md
+++ b/apps/mobile/RELEASE.md
@@ -1,0 +1,69 @@
+# Releasing the mobile app
+
+This covers shipping OpnShelf to TestFlight (iOS) and Play internal testing
+(Android) via EAS. The repo-side config (`eas.json`, the `EAS Build` workflow,
+`store/`, icons in `assets/images/`) is committed; the steps below are the
+external, credentialed parts that can't live in git.
+
+## One-time setup
+
+### 1. Expo / EAS project
+```bash
+cd apps/mobile
+eas login                # an Expo account with the OpnShelf project
+eas init                 # links the project, writes extra.eas.projectId to app.config.ts
+```
+Commit the `extra.eas.projectId` that `eas init` adds.
+
+### 2. Build-time environment variables (EAS)
+`eas.json` no longer hardcodes the production API URL. Set these as EAS
+environment variables, scoped to the `preview` and `production` environments,
+so cloud builds pick them up:
+```bash
+eas env:create --environment preview     --name EXPO_PUBLIC_API_URL    --value "https://<prod-backend-host>"
+eas env:create --environment production   --name EXPO_PUBLIC_API_URL    --value "https://<prod-backend-host>"
+eas env:create --environment production   --name EXPO_PUBLIC_POSTHOG_KEY --value "<posthog key>"  --visibility sensitive
+```
+(Repeat `EXPO_PUBLIC_POSTHOG_KEY` for `preview` if you want analytics there.)
+The `<prod-backend-host>` is the Railway backend URL — **not** `opnshelf.xyz`,
+which is the web frontend.
+
+### 3. CI secret
+Add an Expo access token (`eas whoami`-capable, Personal/Robot token) as the
+`EXPO_TOKEN` GitHub Actions secret so the **EAS Build** workflow can run.
+
+### 4. Store credentials
+- **iOS:** an Apple Developer account ($99/yr). `eas submit` / `eas credentials`
+  will create the App Store Connect app and manage signing. Fill the
+  `submit.production.ios` env vars (`EXPO_APPLE_ID`, `EXPO_ASC_APP_ID`,
+  `EXPO_APPLE_TEAM_ID`) — locally via shell env, in CI via secrets.
+- **Android:** a Google Play Developer account ($25 once). Create the app in the
+  Play Console, then download a service-account JSON with release permissions to
+  `apps/mobile/google-service-account.json` (git-ignored — never commit it).
+
+## Cutting a build
+
+Builds are **manual only** (no auto-build on PRs) — run from the Actions tab →
+**EAS Build** → *Run workflow*, or locally:
+```bash
+cd apps/mobile
+eas build --platform all --profile preview        # internal distribution
+eas build --platform all --profile production --auto-submit
+```
+The workflow's `submit: true` + `profile: production` does the same `--auto-submit`.
+
+## Store listings & privacy
+- iOS listing copy lives in `store/store.config.json`; push it with
+  `eas metadata:push`.
+- Google Play has no EAS metadata equivalent yet — paste fields from
+  `store/listing.md` into the Play Console by hand.
+- Complete **App Privacy** (iOS) and **Data safety** (Play) from
+  `store/data-safety.md`. Keep both in sync with https://opnshelf.xyz/privacy.
+- Provide a demo atproto account (handle + app password) in each store's review
+  notes — sign-in requires an account.
+
+## Testing tracks
+- **iOS:** production builds auto-appear in TestFlight after processing; add
+  internal/external testers in App Store Connect.
+- **Android:** `submit` uploads to the `internal` track (see `eas.json`); promote
+  to closed/open testing in the Play Console when ready.

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -8,6 +8,7 @@ import type { ExpoConfig } from "expo/config";
 const config: ExpoConfig = {
 	name: "OpnShelf",
 	slug: "opnshelf",
+	owner: "rowanpaul",
 	version: "1.0.0",
 	scheme: "opnshelf",
 	orientation: "portrait",
@@ -52,6 +53,9 @@ const config: ExpoConfig = {
 		posthogApiKey: process.env.EXPO_PUBLIC_POSTHOG_KEY,
 		posthogHost:
 			process.env.EXPO_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com",
+		eas: {
+			projectId: "87d86952-59ab-4711-9f5f-f9477b2d14f6",
+		},
 	},
 };
 

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,41 @@
+{
+  "cli": {
+    "version": ">= 12.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "channel": "development",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "http://127.0.0.1:3001"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "channel": "preview",
+      "ios": {
+        "simulator": false
+      }
+    },
+    "production": {
+      "distribution": "store",
+      "channel": "production",
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "appleId": "$EXPO_APPLE_ID",
+        "ascAppId": "$EXPO_ASC_APP_ID",
+        "appleTeamId": "$EXPO_APPLE_TEAM_ID"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./google-service-account.json",
+        "track": "internal"
+      }
+    }
+  }
+}

--- a/apps/mobile/store/data-safety.md
+++ b/apps/mobile/store/data-safety.md
@@ -1,0 +1,44 @@
+# Data collection disclosures
+
+Source of truth for **Apple App Privacy** ("nutrition labels", App Store Connect)
+and **Google Play Data safety**. Derived from the published privacy policy at
+https://opnshelf.xyz/privacy — keep all three in sync when any changes.
+
+Authentication is delegated to the AT Protocol; **we never store passwords**.
+We **do not sell** data and **do not** use data for cross-app tracking
+(`ITSAppUsesNonExemptEncryption: false` and no IDFA/ad SDKs).
+
+## What is collected
+
+| Data | Category | Linked to user | Purpose | Source |
+| --- | --- | --- | --- | --- |
+| Handle, display name, avatar | Account info | Yes | App functionality | Provided by user (atproto account) |
+| Shelf, watch history & dates | User content | Yes | App functionality | Provided by user |
+| Star ratings, notes, reviews | User content | Yes | App functionality | Provided by user |
+| Lists | User content | Yes | App functionality | Provided by user |
+| Follow relationships | User content | Yes | App functionality | Provided by user |
+| IP address, user agent (server logs) | Diagnostics | No | Security, abuse prevention | Automatic |
+| Product analytics (PostHog, EU) | Analytics / product interaction | Yes | Analytics, improve the Service | Automatic |
+
+## Apple App Privacy mapping
+- **Data Used to Track You:** none.
+- **Data Linked to You:** Contact Info (none — no email at signup), User Content
+  (shelf, ratings, reviews, notes, lists), Identifiers (atproto DID/handle),
+  Usage Data (PostHog product analytics).
+- **Data Not Linked to You:** Diagnostics (server logs / crash & performance).
+
+## Google Play Data safety mapping
+- **Data shared with third parties:** none (PostHog is our processor, not a sale).
+- **Data collected:**
+  - Personal info → Name (display name), User IDs (handle/DID).
+  - App activity → In-app actions, other user-generated content (shelf, reviews,
+    ratings, notes, lists), App interactions (PostHog analytics).
+  - App info & performance → Diagnostics (server logs).
+- **Security practices:** data encrypted in transit; user can request deletion
+  (atproto data lives in the user's own PDS and can be deleted there).
+
+## Notes
+- If analytics is disabled in a build (no `EXPO_PUBLIC_POSTHOG_KEY`), the
+  Analytics rows above do not apply to that build.
+- The encryption export-compliance answer is "No" via
+  `ios.infoPlist.ITSAppUsesNonExemptEncryption = false` in `app.config.ts`.

--- a/apps/mobile/store/listing.md
+++ b/apps/mobile/store/listing.md
@@ -1,0 +1,44 @@
+# Store listing copy
+
+Shared source of truth for App Store Connect and Google Play listings. iOS
+metadata is also encoded in `store.config.json` for `eas metadata:push`; Google
+Play has no EAS equivalent yet, so paste the relevant fields into the Play
+Console by hand.
+
+## Name
+OpnShelf
+
+## Subtitle (iOS, ≤30 chars) / Short description (Play, ≤80 chars)
+- iOS: `Track films, shows & books`
+- Play: `Track what you watch. Rate it, review it, own your shelf — built on atproto.`
+
+## Full description
+OpnShelf is a personal media tracker built on the AT Protocol. Log what you
+watch, rate and review it, and keep a shelf you actually own — your data lives
+in your own repository, not locked inside ours.
+
+- Search films and TV shows
+- Log watches with the date you watched
+- Rate with stars and write full reviews
+- Build a shelf of everything you track
+- Sign in with your AT Protocol / Bluesky account
+
+OpnShelf is open and portable: your reviews are standard.site documents in your
+own PDS, so they travel with you across the network.
+
+## Keywords (iOS, comma-separated, ≤100 chars)
+movies,tv shows,tracker,watchlist,reviews,ratings,shelf,atproto,bluesky
+
+## Categories
+- Primary: Entertainment
+- Secondary: Lifestyle
+
+## URLs
+- Marketing: https://opnshelf.xyz
+- Support: https://opnshelf.xyz
+- Privacy policy: https://opnshelf.xyz/privacy
+
+## App review notes
+A working AT Protocol account is required to sign in. Provide a demo account
+(handle + app password) in App Store Connect / Play Console review notes before
+each submission.

--- a/apps/mobile/store/store.config.json
+++ b/apps/mobile/store/store.config.json
@@ -1,0 +1,38 @@
+{
+  "configVersion": 0,
+  "apple": {
+    "info": {
+      "en-US": {
+        "title": "OpnShelf",
+        "subtitle": "Track films, shows & books",
+        "description": "OpnShelf is a personal media tracker built on the AT Protocol. Log what you watch, rate and review it, and keep a shelf you actually own — your data lives in your own repository, not locked inside ours.\n\n- Search films and TV shows\n- Log watches with the date you watched\n- Rate with stars and write full reviews\n- Build a shelf of everything you track\n- Sign in with your AT Protocol / Bluesky account\n\nOpnShelf is open and portable: your reviews are standard.site documents in your own PDS, so they travel with you across the network.",
+        "keywords": [
+          "movies",
+          "tv shows",
+          "tracker",
+          "watchlist",
+          "reviews",
+          "ratings",
+          "shelf",
+          "atproto",
+          "bluesky"
+        ],
+        "marketingUrl": "https://opnshelf.xyz",
+        "privacyPolicyUrl": "https://opnshelf.xyz/privacy",
+        "supportUrl": "https://opnshelf.xyz"
+      }
+    },
+    "categories": ["ENTERTAINMENT", "LIFESTYLE"],
+    "release": {
+      "automaticRelease": false
+    },
+    "review": {
+      "firstName": "Rowan-Paul",
+      "lastName": "Flynn",
+      "email": "rowan-paul@webbio.nl",
+      "demoAccount": {
+        "required": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Phase 4 (#123) release plumbing for the mobile rework. The repo-side, non-credentialed pieces; the external steps (Apple/Google/Expo accounts, `EXPO_TOKEN`) are documented in `apps/mobile/RELEASE.md`.

## What's in here
- **`apps/mobile/eas.json`** — `development` / `preview` / `production` build profiles + a `production` submit profile (Apple via env vars, Android `internal` track). Public env (`EXPO_PUBLIC_API_URL`, PostHog key) is sourced from EAS env vars rather than hardcoded — `opnshelf.xyz` is the web frontend, not the backend.
- **`.github/workflows/eas-build.yml`** — `workflow_dispatch` only (no auto-build on PRs, to save EAS minutes), with platform/profile/submit inputs. Production+submit uses `eas build --auto-submit` so there's no race against a separate submit step. Gated on the `EXPO_TOKEN` secret.
- **`apps/mobile/store/`** — `store.config.json` (iOS, for `eas metadata:push`), `listing.md` (shared listing copy), `data-safety.md` (Apple privacy labels + Play Data Safety, derived from opnshelf.xyz/privacy).
- **`apps/mobile/RELEASE.md`** — runbook for the credentialed/external steps.
- **`.gitignore`** — ignores `google-service-account.json`.

## Acceptance criteria (#123)
- [x] EAS Build config for iOS + Android; `eas-build` workflow
- [x] App icons + splash screen (already present, wired in `app.config.ts`)
- [ ] TestFlight + Play internal testing track — config ready; needs Apple/Google/Expo accounts + `EXPO_TOKEN`
- [x] Basic store metadata + privacy disclosures

🤖 Generated with [Claude Code](https://claude.com/claude-code)