### PR TITLE
feat(mobile): person detail screen with filmography (#127)

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -90,6 +90,7 @@ export default function RootLayout() {
 				<Stack.Screen name="onboarding" />
 				<Stack.Screen name="settings" options={{ headerShown: true }} />
 				<Stack.Screen name="movie/[id]" />
+				<Stack.Screen name="person/[id]" />
 				<Stack.Screen name="show/[id]/index" />
 				<Stack.Screen name="show/[id]/season/[seasonNumber]/index" />
 				<Stack.Screen name="show/[id]/season/[seasonNumber]/episode/[episodeNumber]/index" />

--- a/apps/mobile/src/app/person/[id].tsx
+++ b/apps/mobile/src/app/person/[id].tsx
@@ -1,0 +1,142 @@
+import type { PersonFilmographyItemDto } from "@opnshelf/api";
+import { FlashList } from "@shopify/flash-list";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { useMemo } from "react";
+import { ActivityIndicator, ScrollView, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { FilmographyCard } from "@/components/person/FilmographyCard";
+import { PersonHero } from "@/components/person/PersonHero";
+import { ErrorState, LoadingState } from "@/components/ui/states";
+import { Text } from "@/components/ui/text";
+import { useMovieWatchToggle } from "@/lib/use-movie-watch-toggle";
+import { usePersonDetails, usePersonFilmography } from "@/lib/use-person";
+import { useTwStyle } from "@/lib/use-tw-style";
+
+function sortByDateDesc(items: PersonFilmographyItemDto[]) {
+	return [...items].sort((a, b) => {
+		const dateA = a.release_date || a.first_air_date || "";
+		const dateB = b.release_date || b.first_air_date || "";
+		return dateB.localeCompare(dateA);
+	});
+}
+
+export default function PersonDetailScreen() {
+	const { id } = useLocalSearchParams<{ id: string }>();
+	const insets = useSafeAreaInsets();
+	const gridStyle = useTwStyle("px-3 pb-12");
+
+	const { data: person, isLoading, isError } = usePersonDetails(id);
+	const {
+		data: filmographyData,
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+	} = usePersonFilmography(id);
+
+	const { isAuthenticated, isWatched, toggle } = useMovieWatchToggle();
+
+	const filmography = useMemo(() => {
+		const items = filmographyData?.pages.flatMap((page) => page.items) ?? [];
+		return sortByDateDesc(items);
+	}, [filmographyData]);
+
+	const knownFor = useMemo(
+		() =>
+			[...filmography]
+				.filter((item) => (item.vote_average ?? 0) > 0)
+				.sort((a, b) => (b.vote_average ?? 0) - (a.vote_average ?? 0))
+				.slice(0, 6),
+		[filmography],
+	);
+
+	return (
+		<View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
+			<Stack.Screen options={{ headerShown: false }} />
+			{isLoading ? (
+				<LoadingState />
+			) : isError || !person ? (
+				<ErrorState message="Couldn't load this person." />
+			) : (
+				<FlashList
+					data={filmography}
+					numColumns={3}
+					keyExtractor={(item, index) =>
+						`${item.media_type}-${item.id}-${index}`
+					}
+					renderItem={({ item }) => (
+						<View className="flex-1 px-1 pb-3">
+							<FilmographyCard
+								item={item}
+								canToggle={isAuthenticated}
+								watched={item.media_type === "movie" && isWatched(item.id)}
+								onToggleWatched={(it) => toggle(it.id)}
+							/>
+						</View>
+					)}
+					contentContainerStyle={gridStyle}
+					showsVerticalScrollIndicator={false}
+					onEndReachedThreshold={0.5}
+					onEndReached={() => {
+						if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+					}}
+					ListHeaderComponent={
+						<View className="gap-6 pb-2">
+							<PersonHero person={person} />
+
+							{person.biography ? (
+								<View className="px-4">
+									<Text className="mb-2 font-display font-semibold text-base text-foreground">
+										Biography
+									</Text>
+									<Text className="text-muted-foreground text-sm leading-5">
+										{person.biography}
+									</Text>
+								</View>
+							) : null}
+
+							{knownFor.length > 0 ? (
+								<View>
+									<Text className="mb-3 px-4 font-display font-semibold text-base text-foreground">
+										Known for
+									</Text>
+									<ScrollView
+										horizontal
+										showsHorizontalScrollIndicator={false}
+										contentContainerClassName="gap-3 px-4"
+									>
+										{knownFor.map((item) => (
+											<View
+												key={`known-${item.media_type}-${item.id}`}
+												className="w-28"
+											>
+												<FilmographyCard
+													item={item}
+													canToggle={isAuthenticated}
+													watched={
+														item.media_type === "movie" && isWatched(item.id)
+													}
+													onToggleWatched={(it) => toggle(it.id)}
+												/>
+											</View>
+										))}
+									</ScrollView>
+								</View>
+							) : null}
+
+							<Text className="px-4 font-display font-semibold text-base text-foreground">
+								Filmography
+							</Text>
+						</View>
+					}
+					ListFooterComponent={
+						isFetchingNextPage ? (
+							<View className="py-6">
+								<ActivityIndicator color="#94a3b8" />
+							</View>
+						) : null
+					}
+				/>
+			)}
+		</View>
+	);
+}

--- a/apps/mobile/src/components/detail/CreditsSection.tsx
+++ b/apps/mobile/src/components/detail/CreditsSection.tsx
@@ -1,6 +1,7 @@
 import type { TmdbCastDto, TmdbCrewDto } from "@opnshelf/api";
+import { Link } from "expo-router";
 import { User } from "lucide-react-native";
-import { FlatList, View } from "react-native";
+import { FlatList, Pressable, View } from "react-native";
 import { PosterImage } from "@/components/media/PosterImage";
 import { Text } from "@/components/ui/text";
 import { profileUrl } from "@/lib/tmdb";
@@ -15,26 +16,28 @@ type CreditPerson = {
 function CreditCard({ person }: { person: CreditPerson }) {
 	const url = profileUrl(person.profile_path);
 	return (
-		<View className="w-20">
-			<View className="aspect-2/3 w-20 items-center justify-center overflow-hidden rounded-lg border border-border bg-background-subtle">
-				{url ? (
-					<PosterImage url={url} className="aspect-2/3 w-20" />
-				) : (
-					<User color="#94a3b8" size={24} />
-				)}
-			</View>
-			<Text
-				className="mt-1 font-medium text-foreground text-xs"
-				numberOfLines={1}
-			>
-				{person.name}
-			</Text>
-			{person.role ? (
-				<Text className="text-muted-foreground text-xs" numberOfLines={1}>
-					{person.role}
+		<Link href={`/person/${person.id}` as const} asChild>
+			<Pressable className="w-20">
+				<View className="aspect-2/3 w-20 items-center justify-center overflow-hidden rounded-lg border border-border bg-background-subtle">
+					{url ? (
+						<PosterImage url={url} className="aspect-2/3 w-20" />
+					) : (
+						<User color="#94a3b8" size={24} />
+					)}
+				</View>
+				<Text
+					className="mt-1 font-medium text-foreground text-xs"
+					numberOfLines={1}
+				>
+					{person.name}
 				</Text>
-			) : null}
-		</View>
+				{person.role ? (
+					<Text className="text-muted-foreground text-xs" numberOfLines={1}>
+						{person.role}
+					</Text>
+				) : null}
+			</Pressable>
+		</Link>
 	);
 }
 

--- a/apps/mobile/src/components/person/FilmographyCard.tsx
+++ b/apps/mobile/src/components/person/FilmographyCard.tsx
@@ -1,0 +1,106 @@
+import type { PersonFilmographyItemDto } from "@opnshelf/api";
+import { Link } from "expo-router";
+import { Check, Plus } from "lucide-react-native";
+import { Pressable, View } from "react-native";
+import { PosterImage } from "@/components/media/PosterImage";
+import { Text } from "@/components/ui/text";
+import { posterUrl } from "@/lib/tmdb";
+
+/** Best human-readable role label for a (possibly merged) filmography credit. */
+export function getRoleText(
+	item: PersonFilmographyItemDto,
+): string | undefined {
+	if (item.character) return item.character;
+	if (item.job) return item.job;
+	if (item.roles && item.roles.length > 0) {
+		const roles = item.roles.map((r) => r.character || r.job).filter(Boolean);
+		return [...new Set(roles)].join(" / ") || undefined;
+	}
+	return undefined;
+}
+
+/** 4-digit year from a filmography credit's release / first-air date. */
+export function getYear(item: PersonFilmographyItemDto): string | undefined {
+	const date = item.release_date || item.first_air_date;
+	if (!date) return undefined;
+	const year = new Date(date).getFullYear();
+	return Number.isNaN(year) ? undefined : String(year);
+}
+
+/**
+ * Poster card for a person's filmography. Links to the matching movie/show
+ * detail and, for movies, overlays a quick watched toggle (powered by the
+ * page-level `useMovieWatchToggle`). Shows have no single watched state, so
+ * they just navigate.
+ */
+export function FilmographyCard({
+	item,
+	watched,
+	canToggle,
+	onToggleWatched,
+}: {
+	item: PersonFilmographyItemDto;
+	watched?: boolean;
+	canToggle?: boolean;
+	onToggleWatched?: (item: PersonFilmographyItemDto) => void;
+}) {
+	const isMovie = item.media_type === "movie";
+	const href = isMovie
+		? (`/movie/${item.id}` as const)
+		: (`/show/${item.id}` as const);
+	const role = getRoleText(item);
+	const year = getYear(item);
+	const showToggle = isMovie && canToggle;
+
+	return (
+		<View className="flex-1">
+			<Link href={href} asChild>
+				<Pressable>
+					<View className="overflow-hidden rounded-lg border border-border bg-card">
+						<PosterImage
+							url={posterUrl(item.poster_path)}
+							className="aspect-2/3 w-full"
+						/>
+					</View>
+					<Text
+						className="mt-2 font-medium text-foreground text-sm"
+						numberOfLines={1}
+					>
+						{item.title}
+					</Text>
+					<View className="mt-0.5 flex-row items-center gap-1.5">
+						{year ? (
+							<Text className="text-muted-foreground text-xs">{year}</Text>
+						) : null}
+						{role ? (
+							<Text
+								className="flex-1 text-muted-foreground text-xs"
+								numberOfLines={1}
+							>
+								{role}
+							</Text>
+						) : null}
+					</View>
+				</Pressable>
+			</Link>
+
+			{showToggle ? (
+				<Pressable
+					hitSlop={8}
+					onPress={() => onToggleWatched?.(item)}
+					className={
+						watched
+							? "absolute top-1.5 right-1.5 size-7 items-center justify-center rounded-full bg-primary"
+							: "absolute top-1.5 right-1.5 size-7 items-center justify-center rounded-full bg-black/55"
+					}
+				>
+					{watched ? (
+						<Check color="#3f2e00" size={16} strokeWidth={3} />
+					) : (
+						<Plus color="#ffffff" size={16} strokeWidth={2.5} />
+					)}
+				</Pressable>
+			) : null}
+		</View>
+	);
+}

--- a/apps/mobile/src/components/person/PersonHero.tsx
+++ b/apps/mobile/src/components/person/PersonHero.tsx
@@ -1,0 +1,96 @@
+import type { TmdbPersonDetailDto } from "@opnshelf/api";
+import { Calendar, Clapperboard, MapPin, User } from "lucide-react-native";
+import { View } from "react-native";
+import { PosterImage } from "@/components/media/PosterImage";
+import { Text } from "@/components/ui/text";
+import { profileUrl } from "@/lib/tmdb";
+
+function yearOf(date?: string): number | null {
+	if (!date) return null;
+	const year = new Date(date).getFullYear();
+	return Number.isNaN(year) ? null : year;
+}
+
+function formatDate(iso?: string): string | undefined {
+	if (!iso) return undefined;
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return undefined;
+	return d.toLocaleDateString(undefined, {
+		day: "numeric",
+		month: "short",
+		year: "numeric",
+	});
+}
+
+/**
+ * Header for the person detail screen: portrait photo beside the name, a
+ * department badge, and a compact meta row (born/died, birthplace). Mirrors the
+ * mobile-stacked layout of the web person page.
+ */
+export function PersonHero({ person }: { person: TmdbPersonDetailDto }) {
+	const url = profileUrl(person.profile_path, "h632");
+
+	const birthYear = yearOf(person.birthday);
+	const deathYear = yearOf(person.deathday);
+	const age = birthYear
+		? (deathYear ?? new Date().getFullYear()) - birthYear
+		: null;
+
+	return (
+		<View className="px-4 pt-2">
+			<View className="flex-row gap-4">
+				<View className="h-40 w-28 items-center justify-center overflow-hidden rounded-lg border border-border bg-background-subtle">
+					{url ? (
+						<PosterImage url={url} className="h-40 w-28" />
+					) : (
+						<User color="#94a3b8" size={32} />
+					)}
+				</View>
+				<View className="min-w-0 flex-1 justify-end gap-2 pb-1">
+					<Text className="font-bold font-display text-2xl text-foreground">
+						{person.name}
+					</Text>
+					{person.known_for_department ? (
+						<View className="flex-row">
+							<View className="flex-row items-center gap-1 rounded-full bg-primary px-2.5 py-1">
+								<Clapperboard color="#3f2e00" size={12} />
+								<Text className="font-medium text-primary-foreground text-xs">
+									{person.known_for_department}
+								</Text>
+							</View>
+						</View>
+					) : null}
+				</View>
+			</View>
+
+			<View className="mt-3 gap-1.5">
+				{person.birthday ? (
+					<View className="flex-row items-center gap-1.5">
+						<Calendar color="#94a3b8" size={14} />
+						<Text className="text-muted-foreground text-sm">
+							Born {formatDate(person.birthday)}
+							{age !== null && !person.deathday ? ` (${age})` : ""}
+						</Text>
+					</View>
+				) : null}
+				{person.deathday ? (
+					<View className="flex-row items-center gap-1.5">
+						<Calendar color="#94a3b8" size={14} />
+						<Text className="text-muted-foreground text-sm">
+							Died {formatDate(person.deathday)}
+							{age !== null ? ` (aged ${age})` : ""}
+						</Text>
+					</View>
+				) : null}
+				{person.place_of_birth ? (
+					<View className="flex-row items-center gap-1.5">
+						<MapPin color="#94a3b8" size={14} />
+						<Text className="text-muted-foreground text-sm" numberOfLines={2}>
+							{person.place_of_birth}
+						</Text>
+					</View>
+				) : null}
+			</View>
+		</View>
+	);
+}

--- a/apps/mobile/src/lib/use-movie-watch-toggle.ts
+++ b/apps/mobile/src/lib/use-movie-watch-toggle.ts
@@ -1,0 +1,146 @@
+import {
+	moviesControllerGetUserMoviesOptions,
+	moviesControllerGetUserMoviesQueryKey,
+	moviesControllerMarkWatchedMutation,
+	moviesControllerUnmarkWatchedMutation,
+	shelfControllerGetUserActivitySummaryQueryKey,
+	shelfControllerGetUserShelfQueryKey,
+	type TrackedMovieDto,
+} from "@opnshelf/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import * as Haptics from "expo-haptics";
+import { useCallback, useMemo } from "react";
+import { useToast } from "@/components/ui/toast";
+import { useAuth } from "@/lib/auth-context";
+
+/**
+ * Lightweight bulk movie watch-toggle for list/grid surfaces (e.g. a person's
+ * filmography) where instantiating a full `useWatchActions` per card would be
+ * wasteful. Reads the user's tracked-movies list once to derive watched state,
+ * and exposes a single mark/unmark pair parameterised by `movieId` at call
+ * time. Optimistically patches the shared tracked-movies cache and invalidates
+ * the shelf on settle, matching `use-watch-actions`.
+ *
+ * Movies only — show "watched" is per-episode and can't be a single toggle.
+ */
+export function useMovieWatchToggle() {
+	const { isAuthenticated, user } = useAuth();
+	const userDid = user?.did ?? "";
+	const queryClient = useQueryClient();
+	const toast = useToast();
+
+	const userMoviesKey = moviesControllerGetUserMoviesQueryKey({
+		path: { userDid },
+	});
+
+	const { data: userMovies } = useQuery({
+		...moviesControllerGetUserMoviesOptions({ path: { userDid } }),
+		enabled: isAuthenticated && !!userDid,
+	});
+
+	const watchedIds = useMemo(() => {
+		const set = new Set<string>();
+		if (Array.isArray(userMovies)) {
+			for (const m of userMovies) set.add(String(m.movieId));
+		}
+		return set;
+	}, [userMovies]);
+
+	const invalidateShelf = useCallback(() => {
+		queryClient.invalidateQueries({
+			queryKey: shelfControllerGetUserShelfQueryKey({ path: { userDid } }),
+		});
+		queryClient.invalidateQueries({
+			queryKey: shelfControllerGetUserActivitySummaryQueryKey({
+				path: { userDid },
+			}),
+		});
+	}, [queryClient, userDid]);
+
+	const errorMessage = (error: unknown, fallback: string) =>
+		error instanceof Error ? error.message : fallback;
+
+	const markMovie = useMutation({
+		mutationKey: ["movies", "filmography", "markWatched"],
+		...moviesControllerMarkWatchedMutation(),
+		onMutate: async (variables) => {
+			await queryClient.cancelQueries({ queryKey: userMoviesKey });
+			const prev = queryClient.getQueryData<TrackedMovieDto[]>(userMoviesKey);
+			const movieId = String(variables.body.movieId);
+			queryClient.setQueryData<TrackedMovieDto[]>(userMoviesKey, (old) => {
+				if (!Array.isArray(old)) return old;
+				if (old.some((m) => String(m.movieId) === movieId)) return old;
+				return [...old, { movieId } as TrackedMovieDto];
+			});
+			return { prev };
+		},
+		onError: (error, _vars, context) => {
+			if (context?.prev !== undefined) {
+				queryClient.setQueryData(userMoviesKey, context.prev);
+			}
+			toast.error(errorMessage(error, "Failed to mark as watched"));
+		},
+		onSuccess: () => {
+			void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(
+				() => {},
+			);
+			toast.success("Marked as watched");
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: userMoviesKey });
+			invalidateShelf();
+		},
+	});
+
+	const unmarkMovie = useMutation({
+		mutationKey: ["movies", "filmography", "unmarkWatched"],
+		...moviesControllerUnmarkWatchedMutation(),
+		onMutate: async (variables) => {
+			await queryClient.cancelQueries({ queryKey: userMoviesKey });
+			const prev = queryClient.getQueryData<TrackedMovieDto[]>(userMoviesKey);
+			const movieId = String(variables.path.movieId);
+			queryClient.setQueryData<TrackedMovieDto[]>(userMoviesKey, (old) =>
+				Array.isArray(old)
+					? old.filter((m) => String(m.movieId) !== movieId)
+					: old,
+			);
+			return { prev };
+		},
+		onError: (error, _vars, context) => {
+			if (context?.prev !== undefined) {
+				queryClient.setQueryData(userMoviesKey, context.prev);
+			}
+			toast.error(errorMessage(error, "Failed to remove from watched"));
+		},
+		onSuccess: () => {
+			void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+				() => {},
+			);
+			toast.success("Removed from watched");
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: userMoviesKey });
+			invalidateShelf();
+		},
+	});
+
+	const isWatched = useCallback(
+		(movieId: string | number) => watchedIds.has(String(movieId)),
+		[watchedIds],
+	);
+
+	const toggle = useCallback(
+		(movieId: string | number) => {
+			if (!isAuthenticated) return;
+			const id = String(movieId);
+			if (watchedIds.has(id)) {
+				unmarkMovie.mutate({ path: { movieId: id }, query: { mode: "all" } });
+			} else {
+				markMovie.mutate({ body: { movieId: id } });
+			}
+		},
+		[isAuthenticated, watchedIds, markMovie, unmarkMovie],
+	);
+
+	return { isAuthenticated, isWatched, toggle };
+}

--- a/apps/mobile/src/lib/use-person.ts
+++ b/apps/mobile/src/lib/use-person.ts
@@ -1,0 +1,30 @@
+import {
+	peopleControllerGetPersonDetailsOptions,
+	peopleControllerGetPersonFilmographyInfiniteOptions,
+} from "@opnshelf/api";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+
+/**
+ * Person detail + filmography hooks, mirroring the web `usePersonDetails` /
+ * `usePersonFilmography` so both clients pull from the same generated
+ * `@opnshelf/api` procedures.
+ */
+export function usePersonDetails(personId: string) {
+	return useQuery({
+		...peopleControllerGetPersonDetailsOptions({ path: { personId } }),
+		enabled: !!personId,
+	});
+}
+
+export function usePersonFilmography(personId: string, pageSize = 20) {
+	return useInfiniteQuery({
+		...peopleControllerGetPersonFilmographyInfiniteOptions({
+			path: { personId },
+			query: { pageSize },
+		}),
+		enabled: !!personId,
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) =>
+			lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+	});
+}


### PR DESCRIPTION
Ports the web person page to mobile. Part of the deferred Mobile rework work (#89).

## What
- **Person detail screen** (`/person/[id]`): photo + bio hero, a **Known for** rail (top-rated credits), and a merged cast/crew **filmography** grid with infinite scroll.
- **Watch toggle** on filmography: movies get a quick watched toggle directly on the poster. Shows have no single watched state (per-episode tracking), so they just navigate.
- Cast/crew cards on movie/show detail now link through to the person screen.

## How
- `usePersonDetails` / `usePersonFilmography` mirror the web hooks over the same generated `@opnshelf/api` person procedures — no separate mobile client.
- `useMovieWatchToggle` is a page-level bulk toggle: one shared `getUserMovies` query derives watched state for the whole grid, and a single mark/unmark mutation pair is parameterised by `movieId` at call time (optimistic cache patch + shelf invalidation, matching `use-watch-actions`). This avoids firing N watch-status requests across the grid.

## Verification
- `tsc --noEmit` and `biome check` pass (monorepo pre-commit hook green across all packages).
- Not yet exercised in a simulator — happy to run it through the iOS sim if you want a runtime pass before merge.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)