### PR TITLE
feat(mobile): per-media notes (#128)

### DIFF
--- a/apps/mobile/src/app/movie/[id].tsx
+++ b/apps/mobile/src/app/movie/[id].tsx
@@ -8,6 +8,7 @@ import { DetailHero } from "@/components/detail/DetailHero";
 import { MediaTrackingActions } from "@/components/detail/MediaTrackingActions";
 import { MetadataPills } from "@/components/detail/MetadataPills";
 import { OverviewSection } from "@/components/detail/OverviewSection";
+import { YourNote } from "@/components/detail/YourNote";
 import { YourReviews } from "@/components/detail/YourReviews";
 import { ErrorState, LoadingState } from "@/components/ui/states";
 import {
@@ -60,6 +61,7 @@ export default function MovieDetailScreen() {
 					<CastSection cast={data.credits?.cast} />
 					<CrewSection crew={data.credits?.crew} />
 					<YourReviews mediaType="movie" mediaId={id} />
+					<YourNote mediaType="movie" mediaId={id} />
 				</ScrollView>
 			)}
 		</View>

--- a/apps/mobile/src/app/show/[id]/index.tsx
+++ b/apps/mobile/src/app/show/[id]/index.tsx
@@ -9,6 +9,7 @@ import { MediaTrackingActions } from "@/components/detail/MediaTrackingActions";
 import { MetadataPills } from "@/components/detail/MetadataPills";
 import { OverviewSection } from "@/components/detail/OverviewSection";
 import { SeasonCard } from "@/components/detail/SeasonCard";
+import { YourNote } from "@/components/detail/YourNote";
 import { YourReviews } from "@/components/detail/YourReviews";
 import { ErrorState, LoadingState } from "@/components/ui/states";
 import { Text } from "@/components/ui/text";
@@ -89,6 +90,7 @@ export default function ShowDetailScreen() {
 
 					<CastSection cast={data.credits?.cast} />
 					<YourReviews mediaType="show" mediaId={id} />
+					<YourNote mediaType="show" mediaId={id} />
 				</ScrollView>
 			)}
 		</View>

--- a/apps/mobile/src/components/detail/NoteEditorSheet.tsx
+++ b/apps/mobile/src/components/detail/NoteEditorSheet.tsx
@@ -1,0 +1,113 @@
+import { Trash2, X } from "lucide-react-native";
+import { useEffect, useState } from "react";
+import {
+	KeyboardAvoidingView,
+	Modal,
+	Platform,
+	Pressable,
+	TextInput,
+	View,
+} from "react-native";
+import { Text } from "@/components/ui/text";
+
+interface NoteEditorSheetProps {
+	visible: boolean;
+	onDismiss: () => void;
+	/** Existing note content when editing; empty when writing a new one. */
+	initialContent?: string;
+	/** Whether the sheet is editing an existing note (vs. writing a new one). */
+	isEditing?: boolean;
+	onSave: (content: string) => void;
+	/** Provided only when editing — deletes the note being edited. */
+	onDelete?: () => void;
+	isSaving?: boolean;
+	isDeleting?: boolean;
+}
+
+/**
+ * Bottom-anchored modal for writing or editing the single freeform note on a
+ * media item. Sibling of `ReviewEditorSheet`, but a note is content-only (no
+ * title) and one-per-item. `TextInput`/`Modal` are RN-core so `className`
+ * works directly.
+ */
+export function NoteEditorSheet({
+	visible,
+	onDismiss,
+	initialContent = "",
+	isEditing = false,
+	onSave,
+	onDelete,
+	isSaving = false,
+	isDeleting = false,
+}: NoteEditorSheetProps) {
+	const [content, setContent] = useState(initialContent);
+
+	// Re-sync local state whenever the sheet is (re)opened for a target.
+	useEffect(() => {
+		if (visible) setContent(initialContent);
+	}, [visible, initialContent]);
+
+	const canSave = content.trim().length > 0 && !isSaving;
+
+	return (
+		<Modal
+			visible={visible}
+			animationType="slide"
+			transparent
+			onRequestClose={onDismiss}
+		>
+			<KeyboardAvoidingView
+				behavior={Platform.OS === "ios" ? "padding" : undefined}
+				className="flex-1 justify-end"
+			>
+				<Pressable className="flex-1" onPress={onDismiss} />
+				<View className="gap-4 rounded-t-2xl border border-border bg-card p-5">
+					<View className="flex-row items-center justify-between">
+						<Text className="font-bold font-display text-foreground text-lg">
+							{isEditing ? "Edit note" : "Add a note"}
+						</Text>
+						<Pressable hitSlop={8} onPress={onDismiss}>
+							<X color="#94a3b8" size={22} />
+						</Pressable>
+					</View>
+
+					<TextInput
+						value={content}
+						onChangeText={setContent}
+						placeholder="Your thoughts about this title…"
+						placeholderTextColor="#94a3b8"
+						multiline
+						textAlignVertical="top"
+						maxLength={20000}
+						className="min-h-36 rounded-lg border border-border bg-background-subtle p-3 font-sans text-base text-foreground"
+					/>
+
+					{isEditing && onDelete ? (
+						<Pressable
+							onPress={onDelete}
+							disabled={isDeleting}
+							className="flex-row items-center justify-center gap-2 rounded-lg border border-destructive px-4 py-3"
+							style={{ opacity: isDeleting ? 0.6 : 1 }}
+						>
+							<Trash2 color="#ef4444" size={18} />
+							<Text className="font-semibold text-destructive">
+								Delete note
+							</Text>
+						</Pressable>
+					) : null}
+
+					<Pressable
+						onPress={() => onSave(content)}
+						disabled={!canSave}
+						className="items-center rounded-lg bg-primary py-3"
+						style={{ opacity: canSave ? 1 : 0.5 }}
+					>
+						<Text className="font-semibold text-primary-foreground">
+							{isSaving ? "Saving…" : "Save"}
+						</Text>
+					</Pressable>
+				</View>
+			</KeyboardAvoidingView>
+		</Modal>
+	);
+}

--- a/apps/mobile/src/components/detail/YourNote.tsx
+++ b/apps/mobile/src/components/detail/YourNote.tsx
@@ -1,0 +1,107 @@
+import { Pencil, Plus, StickyNote, Trash2 } from "lucide-react-native";
+import { useState } from "react";
+import { ActivityIndicator, Pressable, View } from "react-native";
+import { NoteEditorSheet } from "@/components/detail/NoteEditorSheet";
+import { Text } from "@/components/ui/text";
+import { useNote } from "@/lib/use-note";
+
+interface YourNoteProps {
+	mediaType: "movie" | "show";
+	mediaId: string;
+}
+
+/**
+ * "Your Note" section for a media detail screen: shows the current user's
+ * single freeform note for this title with edit/delete, or an add affordance
+ * when empty. Mirrors the web `NotesSection`; note authoring/viewing only.
+ */
+export function YourNote({ mediaType, mediaId }: YourNoteProps) {
+	const {
+		note,
+		isAuthenticated,
+		isLoading,
+		saveNote,
+		deleteNote,
+		isSaving,
+		isDeleting,
+	} = useNote({ mediaType, mediaId });
+
+	const [editorVisible, setEditorVisible] = useState(false);
+
+	if (!isAuthenticated) return null;
+
+	const handleSave = (content: string) => {
+		saveNote(content);
+		setEditorVisible(false);
+	};
+
+	const handleDelete = () => {
+		deleteNote();
+		setEditorVisible(false);
+	};
+
+	return (
+		<View className="gap-3 px-4">
+			<View className="flex-row items-center justify-between">
+				<View className="flex-row items-center gap-2">
+					<StickyNote color="#f3bc00" size={18} />
+					<Text className="font-display font-semibold text-base text-foreground">
+						Your Note
+					</Text>
+				</View>
+				{note?.content ? (
+					<View className="flex-row gap-1">
+						<Pressable
+							hitSlop={8}
+							onPress={() => setEditorVisible(true)}
+							className="h-7 w-7 items-center justify-center rounded-md"
+						>
+							<Pencil color="#94a3b8" size={16} />
+						</Pressable>
+						<Pressable
+							hitSlop={8}
+							onPress={() => deleteNote()}
+							disabled={isDeleting}
+							className="h-7 w-7 items-center justify-center rounded-md"
+							style={{ opacity: isDeleting ? 0.5 : 1 }}
+						>
+							<Trash2 color="#ef4444" size={16} />
+						</Pressable>
+					</View>
+				) : null}
+			</View>
+
+			{isLoading ? (
+				<View className="flex-row items-center gap-2 py-2">
+					<ActivityIndicator size="small" />
+					<Text className="text-muted-foreground text-sm">Loading note…</Text>
+				</View>
+			) : note?.content ? (
+				<View className="rounded-xl border border-border bg-card p-3">
+					<Text className="text-muted-foreground text-sm leading-5">
+						{note.content}
+					</Text>
+				</View>
+			) : (
+				<Pressable
+					onPress={() => setEditorVisible(true)}
+					className="flex-row items-center gap-1.5 self-start rounded-lg border border-border px-3 py-1.5"
+				>
+					<Plus color="#94a3b8" size={16} />
+					<Text className="font-medium text-foreground text-sm">Add note</Text>
+				</Pressable>
+			)}
+
+			<NoteEditorSheet
+				visible={editorVisible}
+				onDismiss={() => setEditorVisible(false)}
+				isEditing={!!note?.content}
+				initialContent={note?.content ?? ""}
+				onSave={handleSave}
+				onDelete={note?.id ? handleDelete : undefined}
+				isSaving={isSaving}
+				isDeleting={isDeleting}
+			/>
+		</View>
+	);
+}

--- a/apps/mobile/src/lib/use-note.ts
+++ b/apps/mobile/src/lib/use-note.ts
@@ -1,0 +1,128 @@
+import {
+	notesControllerDeleteNoteMutation,
+	notesControllerGetNoteOptions,
+	notesControllerGetNoteQueryKey,
+	notesControllerUpsertNoteMutation,
+} from "@opnshelf/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import * as Haptics from "expo-haptics";
+import { useToast } from "@/components/ui/toast";
+import { useAuth } from "@/lib/auth-context";
+
+interface NoteTarget {
+	mediaType: "movie" | "show";
+	mediaId: string;
+	seasonNumber?: number;
+	episodeNumber?: number;
+}
+
+function resolveMediaType(
+	mediaType: "movie" | "show",
+	seasonNumber?: number,
+	episodeNumber?: number,
+): "movie" | "show" | "season" | "episode" {
+	if (episodeNumber != null) return "episode";
+	if (seasonNumber != null) return "season";
+	return mediaType;
+}
+
+/**
+ * The current user's single freeform note for a media item, plus upsert/delete
+ * operations. Mirrors the web `useNote`/`useUpsertNote`/`useDeleteNote` hooks
+ * over the shared `@opnshelf/api` note procedures — a note is one-per-item
+ * (upsert), distinct from the zero-or-many long-form reviews in `use-review`.
+ */
+export function useNote(target: NoteTarget) {
+	const { user, isAuthenticated } = useAuth();
+	const userDid = user?.did ?? "";
+	const queryClient = useQueryClient();
+	const toast = useToast();
+
+	const resolvedMediaType = resolveMediaType(
+		target.mediaType,
+		target.seasonNumber,
+		target.episodeNumber,
+	);
+
+	const query = {
+		mediaType: resolvedMediaType,
+		mediaId: target.mediaId,
+		seasonNumber: target.seasonNumber,
+		episodeNumber: target.episodeNumber,
+	};
+
+	const noteKey = notesControllerGetNoteQueryKey({ path: { userDid }, query });
+
+	const noteQuery = useQuery({
+		...notesControllerGetNoteOptions({ path: { userDid }, query }),
+		enabled: isAuthenticated && !!userDid && !!target.mediaId,
+	});
+
+	const note = noteQuery.data ?? null;
+
+	const invalidate = () => {
+		queryClient.invalidateQueries({ queryKey: noteKey });
+	};
+
+	const upsertMutation = useMutation({
+		mutationKey: ["notes", "upsert", resolvedMediaType, target.mediaId],
+		...notesControllerUpsertNoteMutation(),
+	});
+
+	const deleteMutation = useMutation({
+		mutationKey: ["notes", "delete", resolvedMediaType, target.mediaId],
+		...notesControllerDeleteNoteMutation(),
+	});
+
+	/** Create or update the note for this media item. */
+	const saveNote = async (content: string) => {
+		if (!isAuthenticated) return;
+		const trimmed = content.trim();
+		if (!trimmed) return;
+		try {
+			await upsertMutation.mutateAsync({
+				body: {
+					mediaType: resolvedMediaType,
+					mediaId: target.mediaId,
+					seasonNumber: target.seasonNumber,
+					episodeNumber: target.episodeNumber,
+					content: trimmed,
+				},
+			});
+			void Haptics.notificationAsync(
+				Haptics.NotificationFeedbackType.Success,
+			).catch(() => {});
+			toast.success("Note saved");
+		} catch (error) {
+			toast.error(error instanceof Error ? error.message : "Failed to save");
+		} finally {
+			invalidate();
+		}
+	};
+
+	/** Delete the note for this media item. */
+	const deleteNote = async () => {
+		if (!isAuthenticated || !note?.id) return;
+		try {
+			await deleteMutation.mutateAsync({ path: { noteId: note.id } });
+			void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+				() => {},
+			);
+			toast.success("Note deleted");
+		} catch (error) {
+			toast.error(error instanceof Error ? error.message : "Failed to delete");
+		} finally {
+			invalidate();
+		}
+	};
+
+	return {
+		note,
+		isAuthenticated,
+		isLoading: noteQuery.isLoading,
+		saveNote,
+		deleteNote,
+		isSaving: upsertMutation.isPending,
+		isDeleting: deleteMutation.isPending,
+	};
+}


### PR DESCRIPTION
Adds per-media notes to mobile. Part of the deferred Mobile rework work (#89).

## What
A **Your Note** section on the movie and show detail screens: author, view, edit, and delete the single freeform note per title.

## How
- `useNote` mirrors the web `useNote`/`useUpsertNote`/`useDeleteNote` over the same generated `@opnshelf/api` note procedures. A note is one-per-item (upsert), distinct from the zero-or-many long-form reviews handled by `use-review`.
- `NoteEditorSheet` is a content-only bottom sheet — a sibling of the existing `ReviewEditorSheet`.
- `YourNote` renders the note with edit/delete or an add affordance, mirroring the web `NotesSection`. Placed right after `YourReviews` on both detail screens.

## Verification
- `tsc --noEmit` and `biome check` pass (monorepo pre-commit hook green across all packages).
- Not yet exercised in a simulator.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)