### PR TITLE
feat(mobile): Up Next dashboard + release calendar (#126)

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1,24 +1,97 @@
-import { View } from "react-native";
+import { FlashList } from "@shopify/flash-list";
+import { Link } from "expo-router";
+import { CalendarDays, Tv } from "lucide-react-native";
+import { ActivityIndicator, Pressable, View } from "react-native";
 import { Screen } from "@/components/ui/screen";
+import { EmptyState, ErrorState, LoadingState } from "@/components/ui/states";
 import { Text } from "@/components/ui/text";
+import { UpNextCard } from "@/components/up-next/UpNextCard";
+import { useTwStyle } from "@/lib/use-tw-style";
+import { useMarkUpNextEpisode, useUpNext } from "@/lib/use-up-next";
 
 export default function HomeScreen() {
+	const listStyle = useTwStyle("px-4 pb-8");
+	const {
+		items,
+		isLoading,
+		isError,
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+	} = useUpNext();
+	const markEpisode = useMarkUpNextEpisode();
+
+	const handleMarkWatched = (
+		showId: string,
+		seasonNumber: number,
+		episodeNumber: number,
+	) => {
+		markEpisode.mutate({ body: { showId, seasonNumber, episodeNumber } });
+	};
+
+	function renderBody() {
+		if (isLoading) return <LoadingState label="Loading your queue…" />;
+		if (isError) {
+			return <ErrorState message="Couldn't load Up Next. Try again." />;
+		}
+		if (items.length === 0) {
+			return (
+				<EmptyState
+					icon={Tv}
+					title="All caught up!"
+					message="No upcoming episodes to watch. Track a show to see it here."
+				/>
+			);
+		}
+		return (
+			<FlashList
+				data={items}
+				keyExtractor={(item) =>
+					`${item.showId}-${item.nextEpisode.seasonNumber}-${item.nextEpisode.episodeNumber}`
+				}
+				renderItem={({ item }) => (
+					<View className="pb-3">
+						<UpNextCard
+							item={item}
+							onMarkWatched={handleMarkWatched}
+							isMarking={markEpisode.isPending}
+						/>
+					</View>
+				)}
+				contentContainerStyle={listStyle}
+				showsVerticalScrollIndicator={false}
+				onEndReachedThreshold={0.5}
+				onEndReached={() => {
+					if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+				}}
+				ListFooterComponent={
+					isFetchingNextPage ? (
+						<View className="py-6">
+							<ActivityIndicator color="#94a3b8" />
+						</View>
+					) : null
+				}
+			/>
+		);
+	}
+
 	return (
-		<Screen>
-			<View className="flex-1 justify-center gap-2">
-				<Text className="font-bold font-display text-3xl text-foreground">
-					OpnShelf
-				</Text>
-				<Text className="text-base text-muted-foreground">
-					Mobile rework foundation. Tokens, fonts, navigation and the API client
-					are wired up.
-				</Text>
-				<View className="mt-4 self-start rounded-md bg-primary px-4 py-2">
-					<Text className="font-sans font-semibold text-primary-foreground text-sm">
-						Amber accent
-					</Text>
-				</View>
+		<Screen className="px-0">
+			<View className="flex-row items-center justify-between px-4 pb-3">
+				<Text className="font-bold font-display text-2xl">Up Next</Text>
+				<Link href="/calendar" asChild>
+					<Pressable
+						hitSlop={8}
+						className="flex-row items-center gap-1.5 rounded-lg border border-border px-3 py-1.5"
+					>
+						<CalendarDays color="#94a3b8" size={16} />
+						<Text className="font-medium text-foreground text-sm">
+							Calendar
+						</Text>
+					</Pressable>
+				</Link>
 			</View>
+			<View className="flex-1">{renderBody()}</View>
 		</Screen>
 	);
 }

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -89,6 +89,7 @@ export default function RootLayout() {
 				<Stack.Screen name="login" />
 				<Stack.Screen name="onboarding" />
 				<Stack.Screen name="settings" options={{ headerShown: true }} />
+				<Stack.Screen name="calendar" options={{ headerShown: true }} />
 				<Stack.Screen name="movie/[id]" />
 				<Stack.Screen name="show/[id]/index" />
 				<Stack.Screen name="show/[id]/season/[seasonNumber]/index" />

--- a/apps/mobile/src/app/calendar.tsx
+++ b/apps/mobile/src/app/calendar.tsx
@@ -1,0 +1,156 @@
+import type { ReleaseCalendarItemDto } from "@opnshelf/api";
+import { Stack } from "expo-router";
+import { ChevronLeft, ChevronRight } from "lucide-react-native";
+import { useMemo, useState } from "react";
+import { Pressable, ScrollView, View } from "react-native";
+import { ReleaseRow } from "@/components/calendar/ReleaseRow";
+import { ErrorState, LoadingState } from "@/components/ui/states";
+import { Text } from "@/components/ui/text";
+import { useReleaseCalendar } from "@/lib/use-release-calendar";
+
+/** Monday-anchored start of the week containing `date`, at local midnight. */
+function getWeekStart(date: Date): Date {
+	const d = new Date(date);
+	const day = d.getDay();
+	const diff = day === 0 ? 6 : day - 1; // Monday = 0
+	d.setDate(d.getDate() - diff);
+	d.setHours(0, 0, 0, 0);
+	return d;
+}
+
+function addDays(date: Date, n: number): Date {
+	const d = new Date(date);
+	d.setDate(d.getDate() + n);
+	return d;
+}
+
+/** Local YYYY-MM-DD key, matching the calendar item's date prefix. */
+function dateKey(date: Date): string {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+	return dateKey(a) === dateKey(b);
+}
+
+function formatRange(weekStart: Date): string {
+	const end = addDays(weekStart, 6);
+	const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+	return `${weekStart.toLocaleDateString(undefined, opts)} – ${end.toLocaleDateString(undefined, opts)}`;
+}
+
+function formatDayLabel(date: Date): string {
+	if (isSameDay(date, new Date())) return "Today";
+	return date.toLocaleDateString(undefined, {
+		weekday: "short",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+export default function CalendarScreen() {
+	const [weekStart, setWeekStart] = useState(() => getWeekStart(new Date()));
+
+	// Fetch a window around the visible week so adjacent navigation is instant.
+	const startDate = dateKey(addDays(weekStart, -7));
+	const endDate = dateKey(addDays(weekStart, 13));
+	const { data, isLoading, isError } = useReleaseCalendar(startDate, endDate);
+
+	const byDate = useMemo(() => {
+		const map = new Map<string, ReleaseCalendarItemDto[]>();
+		for (const item of data?.items ?? []) {
+			const key = item.releaseDate.split("T")[0];
+			const list = map.get(key);
+			if (list) list.push(item);
+			else map.set(key, [item]);
+		}
+		return map;
+	}, [data]);
+
+	const days = useMemo(
+		() =>
+			Array.from({ length: 7 }, (_, i) => {
+				const date = addDays(weekStart, i);
+				return {
+					date,
+					key: dateKey(date),
+					releases: byDate.get(dateKey(date)) ?? [],
+				};
+			}),
+		[weekStart, byDate],
+	);
+
+	return (
+		<View className="flex-1 bg-background">
+			<Stack.Screen options={{ headerShown: true, title: "Calendar" }} />
+
+			<View className="flex-row items-center justify-between border-border border-b px-4 py-3">
+				<Pressable
+					hitSlop={8}
+					onPress={() => setWeekStart((w) => addDays(w, -7))}
+					className="h-10 w-10 items-center justify-center rounded-lg border border-border"
+				>
+					<ChevronLeft color="#94a3b8" size={20} />
+				</Pressable>
+				<Pressable onPress={() => setWeekStart(getWeekStart(new Date()))}>
+					<Text className="font-display font-semibold text-base text-foreground">
+						{formatRange(weekStart)}
+					</Text>
+					<Text className="text-center text-muted-foreground text-xs">
+						Tap for today
+					</Text>
+				</Pressable>
+				<Pressable
+					hitSlop={8}
+					onPress={() => setWeekStart((w) => addDays(w, 7))}
+					className="h-10 w-10 items-center justify-center rounded-lg border border-border"
+				>
+					<ChevronRight color="#94a3b8" size={20} />
+				</Pressable>
+			</View>
+
+			{isLoading ? (
+				<LoadingState label="Loading calendar…" />
+			) : isError ? (
+				<ErrorState message="Couldn't load the release calendar. Try again." />
+			) : (
+				<ScrollView
+					className="flex-1"
+					contentContainerClassName="gap-5 px-4 py-4 pb-12"
+					showsVerticalScrollIndicator={false}
+				>
+					{days.map((day) => (
+						<View key={day.key} className="gap-2">
+							<Text
+								className={
+									isSameDay(day.date, new Date())
+										? "font-display font-semibold text-base text-primary"
+										: "font-display font-semibold text-base text-foreground"
+								}
+							>
+								{formatDayLabel(day.date)}
+							</Text>
+							{day.releases.length === 0 ? (
+								<Text className="text-muted-foreground text-sm">
+									No releases
+								</Text>
+							) : (
+								<View className="gap-2">
+									{day.releases.map((release) => (
+										<ReleaseRow
+											key={`${release.releaseKind}-${release.movieId ?? release.showId}-${release.seasonNumber ?? ""}-${release.episodeNumber ?? ""}-${release.releaseDate}`}
+											item={release}
+										/>
+									))}
+								</View>
+							)}
+						</View>
+					))}
+				</ScrollView>
+			)}
+		</View>
+	);
+}

--- a/apps/mobile/src/components/calendar/ReleaseRow.tsx
+++ b/apps/mobile/src/components/calendar/ReleaseRow.tsx
@@ -1,0 +1,81 @@
+import type { ReleaseCalendarItemDto } from "@opnshelf/api";
+import { type Href, Link } from "expo-router";
+import { ChevronRight, Film, Tv } from "lucide-react-native";
+import { Pressable, View } from "react-native";
+import { PosterImage } from "@/components/media/PosterImage";
+import { Text } from "@/components/ui/text";
+import { posterUrl } from "@/lib/tmdb";
+
+function displayTitle(item: ReleaseCalendarItemDto): string {
+	if (
+		item.mediaType === "show" &&
+		item.releaseKind === "episode" &&
+		item.seasonNumber !== undefined
+	) {
+		if (item.episodeNumber !== undefined) {
+			return `${item.seasonNumber}x${item.episodeNumber} ${item.title}`;
+		}
+		return `S${item.seasonNumber} ${item.title}`;
+	}
+	return item.title;
+}
+
+function hrefFor(item: ReleaseCalendarItemDto): Href | null {
+	if (item.mediaType === "movie" && item.movieId) {
+		return `/movie/${item.movieId}` as const;
+	}
+	if (
+		item.mediaType === "show" &&
+		item.releaseKind === "episode" &&
+		item.showId &&
+		item.seasonNumber !== undefined &&
+		item.episodeNumber !== undefined
+	) {
+		return `/show/${item.showId}/season/${item.seasonNumber}/episode/${item.episodeNumber}` as Href;
+	}
+	if (item.showId) return `/show/${item.showId}` as const;
+	return null;
+}
+
+/** A single upcoming release in the calendar week list. */
+export function ReleaseRow({ item }: { item: ReleaseCalendarItemDto }) {
+	const href = hrefFor(item);
+	const isMovie = item.mediaType === "movie";
+
+	const body = (
+		<View className="flex-row items-center gap-3 rounded-xl border border-border bg-card p-3">
+			<View className="h-20 w-14 items-center justify-center overflow-hidden rounded-lg bg-background-subtle">
+				{item.posterPath ? (
+					<PosterImage url={posterUrl(item.posterPath)} className="h-20 w-14" />
+				) : isMovie ? (
+					<Film color="#94a3b8" size={22} />
+				) : (
+					<Tv color="#94a3b8" size={22} />
+				)}
+			</View>
+			<View className="min-w-0 flex-1">
+				<Text className="font-medium text-foreground text-sm" numberOfLines={2}>
+					{displayTitle(item)}
+				</Text>
+				<View className="mt-1 flex-row items-center gap-1.5">
+					{isMovie ? (
+						<Film color="#94a3b8" size={13} />
+					) : (
+						<Tv color="#94a3b8" size={13} />
+					)}
+					<Text className="text-muted-foreground text-xs">
+						{isMovie ? "Movie" : "TV"}
+					</Text>
+				</View>
+			</View>
+			<ChevronRight color="#94a3b8" size={18} />
+		</View>
+	);
+
+	if (!href) return body;
+	return (
+		<Link href={href} asChild>
+			<Pressable>{body}</Pressable>
+		</Link>
+	);
+}

--- a/apps/mobile/src/components/up-next/UpNextCard.tsx
+++ b/apps/mobile/src/components/up-next/UpNextCard.tsx
@@ -1,0 +1,107 @@
+import type { UpNextShowDto } from "@opnshelf/api";
+import { Link } from "expo-router";
+import { Calendar, Check } from "lucide-react-native";
+import { Pressable, View } from "react-native";
+import { PosterImage } from "@/components/media/PosterImage";
+import { Text } from "@/components/ui/text";
+import { posterUrl } from "@/lib/tmdb";
+
+function formatAirDate(iso?: string): string | undefined {
+	if (!iso) return undefined;
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return undefined;
+	return d.toLocaleDateString(undefined, {
+		day: "numeric",
+		month: "short",
+		year: "numeric",
+	});
+}
+
+/**
+ * A single Up Next entry: a tracked show's next unwatched episode, with watch
+ * progress and a one-tap "mark watched" action that advances the queue.
+ */
+export function UpNextCard({
+	item,
+	onMarkWatched,
+	isMarking,
+}: {
+	item: UpNextShowDto;
+	onMarkWatched: (
+		showId: string,
+		seasonNumber: number,
+		episodeNumber: number,
+	) => void;
+	isMarking?: boolean;
+}) {
+	const { show, nextEpisode: ep } = item;
+	const progress =
+		item.totalEpisodes > 0
+			? Math.round((item.episodesWatched / item.totalEpisodes) * 100)
+			: 0;
+	const airDate = formatAirDate(ep.airDate);
+
+	return (
+		<View className="flex-row gap-3 rounded-xl border border-border bg-card p-3">
+			<Link href={`/show/${show.showId}` as const} asChild>
+				<Pressable className="overflow-hidden rounded-lg border border-border bg-background-subtle">
+					<PosterImage url={posterUrl(show.posterPath)} className="h-32 w-22" />
+				</Pressable>
+			</Link>
+
+			<View className="min-w-0 flex-1 justify-between">
+				<View className="gap-0.5">
+					<View className="flex-row items-start justify-between gap-2">
+						<Text
+							className="flex-1 font-semibold text-foreground text-sm"
+							numberOfLines={1}
+						>
+							{show.title}
+						</Text>
+						<View className="rounded-full bg-primary px-2 py-0.5">
+							<Text className="font-medium text-primary-foreground text-xs">
+								S{ep.seasonNumber}E{ep.episodeNumber}
+							</Text>
+						</View>
+					</View>
+					<Text className="text-muted-foreground text-sm" numberOfLines={1}>
+						{ep.name || `Episode ${ep.episodeNumber}`}
+					</Text>
+					{airDate ? (
+						<View className="mt-0.5 flex-row items-center gap-1.5">
+							<Calendar color="#94a3b8" size={13} />
+							<Text className="text-muted-foreground text-xs">{airDate}</Text>
+						</View>
+					) : null}
+				</View>
+
+				<View className="mt-2 gap-2">
+					<View className="flex-row items-center gap-2">
+						<View className="h-1.5 flex-1 overflow-hidden rounded-full bg-background-subtle">
+							<View
+								className="h-full rounded-full bg-primary"
+								style={{ width: `${progress}%` }}
+							/>
+						</View>
+						<Text className="text-muted-foreground text-xs">
+							{item.episodesWatched}/{item.totalEpisodes}
+						</Text>
+					</View>
+					<Pressable
+						onPress={() =>
+							onMarkWatched(item.showId, ep.seasonNumber, ep.episodeNumber)
+						}
+						disabled={isMarking}
+						className="flex-row items-center justify-center gap-1.5 rounded-lg bg-primary py-2"
+						style={{ opacity: isMarking ? 0.6 : 1 }}
+					>
+						<Check color="#3f2e00" size={16} strokeWidth={3} />
+						<Text className="font-semibold text-primary-foreground text-sm">
+							Mark watched
+						</Text>
+					</Pressable>
+				</View>
+			</View>
+		</View>
+	);
+}

--- a/apps/mobile/src/lib/use-release-calendar.ts
+++ b/apps/mobile/src/lib/use-release-calendar.ts
@@ -1,0 +1,24 @@
+import { showsControllerGetUserReleaseCalendarOptions } from "@opnshelf/api";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/lib/auth-context";
+
+/**
+ * Upcoming releases for the current user's tracked shows/watchlist within a
+ * date range (YYYY-MM-DD). Mirrors the web calendar route over the shared
+ * `showsControllerGetUserReleaseCalendar` procedure. Previous data is kept
+ * while a new range loads so week navigation stays smooth.
+ */
+export function useReleaseCalendar(startDate: string, endDate: string) {
+	const { user, isAuthenticated } = useAuth();
+	const userDid = user?.did ?? "";
+
+	return useQuery({
+		...showsControllerGetUserReleaseCalendarOptions({
+			path: { userDid },
+			query: { startDate, endDate },
+		}),
+		enabled: isAuthenticated && !!userDid,
+		placeholderData: keepPreviousData,
+		staleTime: 5 * 60 * 1000,
+	});
+}

--- a/apps/mobile/src/lib/use-up-next.ts
+++ b/apps/mobile/src/lib/use-up-next.ts
@@ -1,0 +1,95 @@
+import {
+	shelfControllerGetUserActivitySummaryQueryKey,
+	shelfControllerGetUserShelfQueryKey,
+	showsControllerGetShowWatchHistoryQueryKey,
+	showsControllerGetUserUpNextInfiniteOptions,
+	showsControllerGetUserUpNextQueryKey,
+	showsControllerMarkWatchedMutation,
+} from "@opnshelf/api";
+import {
+	useInfiniteQuery,
+	useMutation,
+	useQueryClient,
+} from "@tanstack/react-query";
+import * as Haptics from "expo-haptics";
+import { useToast } from "@/components/ui/toast";
+import { useAuth } from "@/lib/auth-context";
+
+/**
+ * The current user's "Up Next" queue — tracked shows with their next unwatched
+ * episode — as an infinite list. Mirrors the web up-next route over the shared
+ * `showsControllerGetUserUpNext` procedure.
+ */
+export function useUpNext(pageSize = 20) {
+	const { user, isAuthenticated } = useAuth();
+	const userDid = user?.did ?? "";
+
+	const query = useInfiniteQuery({
+		...showsControllerGetUserUpNextInfiniteOptions({
+			path: { userDid },
+			query: { pageSize },
+		}),
+		enabled: isAuthenticated && !!userDid,
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) =>
+			lastPage.hasNextPage ? lastPage.page + 1 : undefined,
+	});
+
+	const items = query.data?.pages.flatMap((page) => page.items) ?? [];
+
+	return {
+		items,
+		isLoading: query.isLoading,
+		isError: query.isError,
+		fetchNextPage: query.fetchNextPage,
+		hasNextPage: query.hasNextPage,
+		isFetchingNextPage: query.isFetchingNextPage,
+		refetch: query.refetch,
+	};
+}
+
+/**
+ * Mark an episode watched from the Up Next queue. Invalidates the up-next list
+ * (the "current" episode advances), the show's watch history, and the shelf —
+ * mirroring the web `useMarkEpisodeWatched`.
+ */
+export function useMarkUpNextEpisode() {
+	const { user } = useAuth();
+	const userDid = user?.did ?? "";
+	const queryClient = useQueryClient();
+	const toast = useToast();
+
+	return useMutation({
+		mutationKey: ["shows", "upNext", "markEpisodeWatched"],
+		...showsControllerMarkWatchedMutation(),
+		onSuccess: (_data, variables) => {
+			void Haptics.notificationAsync(
+				Haptics.NotificationFeedbackType.Success,
+			).catch(() => {});
+			toast.success("Episode marked as watched");
+			queryClient.invalidateQueries({
+				queryKey: showsControllerGetShowWatchHistoryQueryKey({
+					path: { userDid, showId: variables.body.showId },
+				}),
+			});
+			queryClient.invalidateQueries({
+				queryKey: showsControllerGetUserUpNextQueryKey({ path: { userDid } }),
+			});
+			queryClient.invalidateQueries({
+				queryKey: shelfControllerGetUserShelfQueryKey({ path: { userDid } }),
+			});
+			queryClient.invalidateQueries({
+				queryKey: shelfControllerGetUserActivitySummaryQueryKey({
+					path: { userDid },
+				}),
+			});
+		},
+		onError: (error) => {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Failed to mark episode as watched",
+			);
+		},
+	});
+}


### PR DESCRIPTION
Adds the Up Next queue and a release calendar to mobile. Part of the deferred Mobile rework work (#89).

## What
- **Home tab is now the Up Next dashboard** (it was placeholder scaffolding): an infinite list of tracked shows' next unwatched episode, with watch progress and a one-tap **Mark watched** that advances the queue. A header button opens the calendar.
- **Calendar screen** (`/calendar`): week-navigable list of upcoming releases for your tracked shows / watchlist, grouped by day, each row linking to the movie/show/episode detail.

## How
- `useUpNext` is an infinite query over `showsControllerGetUserUpNext`; `useMarkUpNextEpisode` marks an episode and invalidates the up-next list, the show's watch history, and the shelf (mirrors web `useMarkEpisodeWatched`).
- `useReleaseCalendar` wraps `showsControllerGetUserReleaseCalendar` for a date window with `keepPreviousData` so week navigation stays smooth. The screen fetches a window around the visible week and groups locally.

## Note on scope
Home was an empty placeholder, so I made it the Up Next dashboard — the natural "what to watch next" home for a tracking app. If a different Home design is planned, easy to move Up Next to its own route instead; say the word.

## Verification
- `tsc --noEmit` and `biome check` pass (monorepo pre-commit hook green across all packages).
- Not yet exercised in a simulator.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)