### PR TITLE
feat(mobile): social / friends (#125)

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -1,15 +1,29 @@
 import { Link } from "expo-router";
-import { View } from "react-native";
+import { ChevronRight, Settings, Users } from "lucide-react-native";
+import { Pressable, View } from "react-native";
 import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
 
 export default function ProfileScreen() {
 	return (
-		<Screen>
-			<View className="flex-1 justify-center gap-3">
-				<Text className="font-display font-semibold text-2xl">Profile</Text>
-				<Link href="/settings" className="font-medium text-accent text-base">
-					Open settings
+		<Screen className="px-0">
+			<View className="px-4 pb-3">
+				<Text className="font-bold font-display text-2xl">Profile</Text>
+			</View>
+			<View className="gap-2 px-4">
+				<Link href="/friends" asChild>
+					<Pressable className="flex-row items-center gap-3 rounded-xl border border-border bg-card p-4">
+						<Users color="#94a3b8" size={20} />
+						<Text className="flex-1 font-medium text-foreground">Friends</Text>
+						<ChevronRight color="#94a3b8" size={18} />
+					</Pressable>
+				</Link>
+				<Link href="/settings" asChild>
+					<Pressable className="flex-row items-center gap-3 rounded-xl border border-border bg-card p-4">
+						<Settings color="#94a3b8" size={20} />
+						<Text className="flex-1 font-medium text-foreground">Settings</Text>
+						<ChevronRight color="#94a3b8" size={18} />
+					</Pressable>
 				</Link>
 			</View>
 		</Screen>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -89,6 +89,7 @@ export default function RootLayout() {
 				<Stack.Screen name="login" />
 				<Stack.Screen name="onboarding" />
 				<Stack.Screen name="settings" options={{ headerShown: true }} />
+				<Stack.Screen name="friends" options={{ headerShown: true }} />
 				<Stack.Screen name="movie/[id]" />
 				<Stack.Screen name="show/[id]/index" />
 				<Stack.Screen name="show/[id]/season/[seasonNumber]/index" />

--- a/apps/mobile/src/app/friends.tsx
+++ b/apps/mobile/src/app/friends.tsx
@@ -1,0 +1,182 @@
+import {
+	type SocialUserCardDto,
+	socialControllerSearchPeopleOptions,
+} from "@opnshelf/api";
+import { FlashList } from "@shopify/flash-list";
+import { useQuery } from "@tanstack/react-query";
+import { Stack } from "expo-router";
+import { Search, Users, UserX, X } from "lucide-react-native";
+import { useState } from "react";
+import { ActivityIndicator, Pressable, TextInput, View } from "react-native";
+import { UserRow } from "@/components/social/UserRow";
+import { EmptyState, ErrorState, LoadingState } from "@/components/ui/states";
+import { Text } from "@/components/ui/text";
+import { useAuth } from "@/lib/auth-context";
+import { cn } from "@/lib/cn";
+import { useDebounce } from "@/lib/use-debounce";
+import { useFollowers, useFollowing, useFollowToggle } from "@/lib/use-social";
+import { useTwStyle } from "@/lib/use-tw-style";
+
+type Tab = "following" | "followers";
+
+export default function FriendsScreen() {
+	const { user } = useAuth();
+	const handle = user?.handle ?? "";
+	const myDid = user?.did ?? "";
+
+	const [tab, setTab] = useState<Tab>("following");
+	const [query, setQuery] = useState("");
+	const debouncedQuery = useDebounce(query.trim(), 350);
+	const hasQuery = debouncedQuery.length > 0;
+
+	const listStyle = useTwStyle("px-4 pb-8");
+
+	const following = useFollowing(handle);
+	const followers = useFollowers(handle);
+	const { toggle } = useFollowToggle();
+
+	const peopleQuery = useQuery({
+		...socialControllerSearchPeopleOptions({
+			query: { q: debouncedQuery, pageSize: 20 },
+		}),
+		enabled: hasQuery,
+	});
+
+	const active = tab === "following" ? following : followers;
+	const searchResults = peopleQuery.data?.items ?? [];
+
+	const renderRow = (item: SocialUserCardDto) => (
+		<View className="pb-2">
+			<UserRow
+				user={item}
+				isSelf={item.did === myDid}
+				onToggleFollow={toggle}
+			/>
+		</View>
+	);
+
+	function renderBody() {
+		if (hasQuery) {
+			if (peopleQuery.isLoading) return <LoadingState label="Searching…" />;
+			if (peopleQuery.isError) {
+				return <ErrorState message="Couldn't search people. Try again." />;
+			}
+			if (searchResults.length === 0) {
+				return (
+					<EmptyState
+						icon={Users}
+						title="No people found"
+						message={`No users match “${debouncedQuery}”.`}
+					/>
+				);
+			}
+			return (
+				<FlashList
+					data={searchResults}
+					keyExtractor={(item) => item.did}
+					renderItem={({ item }) => renderRow(item)}
+					contentContainerStyle={listStyle}
+					keyboardShouldPersistTaps="handled"
+				/>
+			);
+		}
+
+		if (active.isLoading) return <LoadingState />;
+		if (active.isError) {
+			return <ErrorState message="Couldn't load this list. Try again." />;
+		}
+		if (active.items.length === 0) {
+			return (
+				<EmptyState
+					icon={UserX}
+					title={tab === "following" ? "Not following anyone" : "No followers"}
+					message={
+						tab === "following"
+							? "Search above to find people to follow."
+							: "When people follow you, they'll show up here."
+					}
+				/>
+			);
+		}
+		return (
+			<FlashList
+				data={active.items}
+				keyExtractor={(item) => item.did}
+				renderItem={({ item }) => renderRow(item)}
+				contentContainerStyle={listStyle}
+				keyboardShouldPersistTaps="handled"
+				onEndReachedThreshold={0.5}
+				onEndReached={() => {
+					if (active.hasNextPage && !active.isFetchingNextPage) {
+						active.fetchNextPage();
+					}
+				}}
+				ListFooterComponent={
+					active.isFetchingNextPage ? (
+						<View className="py-6">
+							<ActivityIndicator color="#94a3b8" />
+						</View>
+					) : null
+				}
+			/>
+		);
+	}
+
+	return (
+		<View className="flex-1 bg-background">
+			<Stack.Screen options={{ headerShown: true, title: "Friends" }} />
+
+			<View className="px-4 pt-3 pb-3">
+				<View className="flex-row items-center gap-2 rounded-lg border border-border bg-card px-3">
+					<Search color="#94a3b8" size={18} />
+					<TextInput
+						value={query}
+						onChangeText={setQuery}
+						placeholder="Find people to follow…"
+						placeholderTextColor="#94a3b8"
+						autoCapitalize="none"
+						autoCorrect={false}
+						returnKeyType="search"
+						className="h-11 flex-1 font-sans text-base text-foreground"
+					/>
+					{query.length > 0 ? (
+						<Pressable hitSlop={8} onPress={() => setQuery("")}>
+							<X color="#94a3b8" size={18} />
+						</Pressable>
+					) : null}
+				</View>
+
+				{hasQuery ? null : (
+					<View className="mt-3 flex-row gap-2">
+						{(["following", "followers"] as const).map((key) => {
+							const isActive = tab === key;
+							return (
+								<Pressable
+									key={key}
+									onPress={() => setTab(key)}
+									className={cn(
+										"rounded-full px-3 py-1.5",
+										isActive ? "bg-primary" : "bg-background-subtle",
+									)}
+								>
+									<Text
+										className={cn(
+											"font-medium text-sm capitalize",
+											isActive
+												? "text-primary-foreground"
+												: "text-muted-foreground",
+										)}
+									>
+										{key}
+									</Text>
+								</Pressable>
+							);
+						})}
+					</View>
+				)}
+			</View>
+
+			<View className="flex-1">{renderBody()}</View>
+		</View>
+	);
+}

--- a/apps/mobile/src/app/movie/[id].tsx
+++ b/apps/mobile/src/app/movie/[id].tsx
@@ -5,6 +5,7 @@ import { ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CastSection, CrewSection } from "@/components/detail/CreditsSection";
 import { DetailHero } from "@/components/detail/DetailHero";
+import { FriendWatchers } from "@/components/detail/FriendWatchers";
 import { MediaTrackingActions } from "@/components/detail/MediaTrackingActions";
 import { MetadataPills } from "@/components/detail/MetadataPills";
 import { OverviewSection } from "@/components/detail/OverviewSection";
@@ -55,6 +56,8 @@ export default function MovieDetailScreen() {
 					</DetailHero>
 
 					<MediaTrackingActions mediaType="movie" movieId={id} />
+
+					<FriendWatchers mediaType="movie" mediaId={id} />
 
 					<OverviewSection text={data.overview} />
 					<CastSection cast={data.credits?.cast} />

--- a/apps/mobile/src/app/show/[id]/index.tsx
+++ b/apps/mobile/src/app/show/[id]/index.tsx
@@ -5,6 +5,7 @@ import { ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CastSection } from "@/components/detail/CreditsSection";
 import { DetailHero } from "@/components/detail/DetailHero";
+import { FriendWatchers } from "@/components/detail/FriendWatchers";
 import { MediaTrackingActions } from "@/components/detail/MediaTrackingActions";
 import { MetadataPills } from "@/components/detail/MetadataPills";
 import { OverviewSection } from "@/components/detail/OverviewSection";
@@ -63,6 +64,8 @@ export default function ShowDetailScreen() {
 					</DetailHero>
 
 					<MediaTrackingActions mediaType="show" showId={id} />
+
+					<FriendWatchers mediaType="show" mediaId={id} />
 
 					<OverviewSection text={data.overview} />
 

--- a/apps/mobile/src/components/detail/FriendWatchers.tsx
+++ b/apps/mobile/src/components/detail/FriendWatchers.tsx
@@ -1,0 +1,63 @@
+import { Image } from "expo-image";
+import { User } from "lucide-react-native";
+import { ScrollView, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useWatchers } from "@/lib/use-social";
+import { useTwStyle } from "@/lib/use-tw-style";
+
+/**
+ * Horizontal row of avatars for people the current user follows who have
+ * watched this title. Renders nothing when there are none. Backed by
+ * `socialControllerGetWatchers`.
+ */
+export function FriendWatchers({
+	mediaType,
+	mediaId,
+}: {
+	mediaType: "movie" | "show";
+	mediaId: string;
+}) {
+	const avatarStyle = useTwStyle("size-10");
+	const { data } = useWatchers(mediaType, mediaId);
+	const watchers = data?.items ?? [];
+
+	if (watchers.length === 0) return null;
+
+	return (
+		<View className="gap-2 px-4">
+			<Text className="font-display font-semibold text-base text-foreground">
+				Watched by friends
+			</Text>
+			<ScrollView
+				horizontal
+				showsHorizontalScrollIndicator={false}
+				contentContainerClassName="gap-3"
+			>
+				{watchers.map(({ actor }) => {
+					const name = actor.displayName || actor.handle;
+					return (
+						<View key={actor.did} className="w-14 items-center gap-1">
+							<View className="size-10 items-center justify-center overflow-hidden rounded-full bg-background-subtle">
+								{actor.avatar ? (
+									<Image
+										source={{ uri: actor.avatar }}
+										style={avatarStyle}
+										contentFit="cover"
+									/>
+								) : (
+									<User color="#94a3b8" size={18} />
+								)}
+							</View>
+							<Text
+								className="text-center text-muted-foreground text-xs"
+								numberOfLines={1}
+							>
+								{name}
+							</Text>
+						</View>
+					);
+				})}
+			</ScrollView>
+		</View>
+	);
+}

--- a/apps/mobile/src/components/social/FollowButton.tsx
+++ b/apps/mobile/src/components/social/FollowButton.tsx
@@ -1,0 +1,56 @@
+import { Check, UserPlus } from "lucide-react-native";
+import { useEffect, useState } from "react";
+import { Pressable } from "react-native";
+import { Text } from "@/components/ui/text";
+import { cn } from "@/lib/cn";
+
+/**
+ * Optimistic follow/unfollow toggle. Holds local state so the tap feels
+ * instant; re-syncs to the server value when the parent's `following` prop
+ * changes (after the social caches are invalidated and refetch).
+ */
+export function FollowButton({
+	following,
+	onToggle,
+}: {
+	following: boolean;
+	onToggle: (currentlyFollowing: boolean) => void;
+}) {
+	const [optimistic, setOptimistic] = useState(following);
+
+	useEffect(() => {
+		setOptimistic(following);
+	}, [following]);
+
+	const handlePress = () => {
+		onToggle(optimistic);
+		setOptimistic((v) => !v);
+	};
+
+	return (
+		<Pressable
+			onPress={handlePress}
+			hitSlop={6}
+			className={cn(
+				"flex-row items-center gap-1.5 rounded-full px-3 py-1.5",
+				optimistic ? "border border-border bg-card" : "bg-primary",
+			)}
+		>
+			{optimistic ? (
+				<>
+					<Check color="#94a3b8" size={14} strokeWidth={3} />
+					<Text className="font-medium text-muted-foreground text-xs">
+						Following
+					</Text>
+				</>
+			) : (
+				<>
+					<UserPlus color="#3f2e00" size={14} />
+					<Text className="font-medium text-primary-foreground text-xs">
+						Follow
+					</Text>
+				</>
+			)}
+		</Pressable>
+	);
+}

--- a/apps/mobile/src/components/social/UserRow.tsx
+++ b/apps/mobile/src/components/social/UserRow.tsx
@@ -1,0 +1,61 @@
+import type { SocialUserCardDto } from "@opnshelf/api";
+import { Image } from "expo-image";
+import { User } from "lucide-react-native";
+import { View } from "react-native";
+import { FollowButton } from "@/components/social/FollowButton";
+import { Text } from "@/components/ui/text";
+import { useTwStyle } from "@/lib/use-tw-style";
+
+/**
+ * A social user row: avatar, display name, handle, and a follow toggle. The
+ * `displayName`/`avatar` fields arrive as loosely-typed JSON from the API, so
+ * they are coerced to strings defensively (matching `PersonRow`). The follow
+ * button is hidden for the current user's own card.
+ */
+export function UserRow({
+	user,
+	isSelf,
+	onToggleFollow,
+}: {
+	user: SocialUserCardDto;
+	isSelf?: boolean;
+	onToggleFollow: (targetDid: string, currentlyFollowing: boolean) => void;
+}) {
+	const avatarStyle = useTwStyle("size-11");
+	const displayName =
+		typeof user.displayName === "string" ? user.displayName : undefined;
+	const avatar = typeof user.avatar === "string" ? user.avatar : undefined;
+	const name = displayName || user.handle;
+
+	return (
+		<View className="flex-row items-center gap-3 rounded-lg border border-border bg-card p-3">
+			<View className="size-11 items-center justify-center overflow-hidden rounded-full bg-background-subtle">
+				{avatar ? (
+					<Image
+						source={{ uri: avatar }}
+						style={avatarStyle}
+						contentFit="cover"
+					/>
+				) : (
+					<User color="#94a3b8" size={20} />
+				)}
+			</View>
+			<View className="min-w-0 flex-1">
+				<Text className="font-medium text-foreground text-sm" numberOfLines={1}>
+					{name}
+				</Text>
+				<Text className="text-muted-foreground text-xs" numberOfLines={1}>
+					@{user.handle}
+				</Text>
+			</View>
+			{isSelf ? null : (
+				<FollowButton
+					following={user.isFollowing}
+					onToggle={(currentlyFollowing) =>
+						onToggleFollow(user.did, currentlyFollowing)
+					}
+				/>
+			)}
+		</View>
+	);
+}

--- a/apps/mobile/src/lib/use-social.ts
+++ b/apps/mobile/src/lib/use-social.ts
@@ -1,0 +1,136 @@
+import {
+	socialControllerFollowMutation,
+	socialControllerGetFollowersInfiniteOptions,
+	socialControllerGetFollowingInfiniteOptions,
+	socialControllerGetWatchersOptions,
+	socialControllerUnfollowMutation,
+} from "@opnshelf/api";
+import {
+	useInfiniteQuery,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import * as Haptics from "expo-haptics";
+import { useToast } from "@/components/ui/toast";
+import { useAuth } from "@/lib/auth-context";
+
+const SOCIAL_QUERY_IDS = [
+	"socialControllerGetFollowing",
+	"socialControllerGetFollowers",
+	"socialControllerSearchPeople",
+	"socialControllerGetWatchers",
+	"socialControllerGetRelationship",
+	"socialControllerGetSuggestions",
+];
+
+/** Infinite list of users `handle` follows. */
+export function useFollowing(handle: string, pageSize = 20) {
+	const query = useInfiniteQuery({
+		...socialControllerGetFollowingInfiniteOptions({
+			path: { handle },
+			query: { pageSize },
+		}),
+		enabled: !!handle,
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) =>
+			lastPage.hasNextPage ? lastPage.page + 1 : undefined,
+	});
+	return {
+		items: query.data?.pages.flatMap((p) => p.items) ?? [],
+		isLoading: query.isLoading,
+		isError: query.isError,
+		fetchNextPage: query.fetchNextPage,
+		hasNextPage: query.hasNextPage,
+		isFetchingNextPage: query.isFetchingNextPage,
+	};
+}
+
+/** Infinite list of `handle`'s followers. */
+export function useFollowers(handle: string, pageSize = 20) {
+	const query = useInfiniteQuery({
+		...socialControllerGetFollowersInfiniteOptions({
+			path: { handle },
+			query: { pageSize },
+		}),
+		enabled: !!handle,
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) =>
+			lastPage.hasNextPage ? lastPage.page + 1 : undefined,
+	});
+	return {
+		items: query.data?.pages.flatMap((p) => p.items) ?? [],
+		isLoading: query.isLoading,
+		isError: query.isError,
+		fetchNextPage: query.fetchNextPage,
+		hasNextPage: query.hasNextPage,
+		isFetchingNextPage: query.isFetchingNextPage,
+	};
+}
+
+/** Followed users who have watched a given media item (for the watchers row). */
+export function useWatchers(
+	mediaType: "movie" | "show",
+	mediaId: string,
+	pageSize = 12,
+) {
+	const { isAuthenticated } = useAuth();
+	return useQuery({
+		...socialControllerGetWatchersOptions({
+			query: { mediaType, mediaId, pageSize },
+		}),
+		enabled: isAuthenticated && !!mediaId,
+	});
+}
+
+/**
+ * Follow / unfollow toggle. The button owns optimistic UI; this hook fires the
+ * mutation and, on settle, invalidates every social surface (following,
+ * followers, search, watchers, relationship) so counts and follow state across
+ * screens reconcile.
+ */
+export function useFollowToggle() {
+	const { isAuthenticated } = useAuth();
+	const queryClient = useQueryClient();
+	const toast = useToast();
+
+	const invalidateSocial = () => {
+		queryClient.invalidateQueries({
+			predicate: (q) => {
+				const key = q.queryKey[0] as { _id?: string } | undefined;
+				return !!key?._id && SOCIAL_QUERY_IDS.includes(key._id);
+			},
+		});
+	};
+
+	const followMutation = useMutation({
+		mutationKey: ["social", "follow"],
+		...socialControllerFollowMutation(),
+		onError: (error) =>
+			toast.error(error instanceof Error ? error.message : "Failed to follow"),
+		onSettled: invalidateSocial,
+	});
+
+	const unfollowMutation = useMutation({
+		mutationKey: ["social", "unfollow"],
+		...socialControllerUnfollowMutation(),
+		onError: (error) =>
+			toast.error(
+				error instanceof Error ? error.message : "Failed to unfollow",
+			),
+		onSettled: invalidateSocial,
+	});
+
+	/** Toggle follow state for a user. `currentlyFollowing` is the pre-tap state. */
+	const toggle = (targetDid: string, currentlyFollowing: boolean) => {
+		if (!isAuthenticated) return;
+		void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+		if (currentlyFollowing) {
+			unfollowMutation.mutate({ path: { targetDid } });
+		} else {
+			followMutation.mutate({ path: { targetDid } });
+		}
+	};
+
+	return { toggle, isAuthenticated };
+}


### PR DESCRIPTION
Adds social / friends to mobile. Part of the deferred Mobile rework work (#89).

## What
- **Friends screen** (`/friends`, reached from the Profile tab): **Following** / **Followers** tabs (infinite scroll) plus a people-search field to discover and follow users. Each row has an optimistic **Follow / Following** toggle.
- **Friend watchers row** on movie/show detail: avatars of people you follow who have watched the title.

## How
- `use-social`: `useFollowing`/`useFollowers` (infinite over the social profile endpoints), `useWatchers` (`socialControllerGetWatchers`), and `useFollowToggle`. The toggle fires follow/unfollow and, on settle, invalidates every social surface (following, followers, search, watchers, relationship) via a query-id predicate so counts and follow state reconcile everywhere.
- `FollowButton` owns optimistic local state for an instant tap, re-syncing to the server value after refetch.
- Profile tab is now a small menu (Friends, Settings) instead of a bare settings link.

## Note
The web app has no friend-watchers row yet — this is built fresh on mobile against the existing `socialControllerGetWatchers` procedure. There's no public-profile screen on mobile yet, so user rows don't navigate to a profile (follow toggle only).

## Verification
- `tsc --noEmit` and `biome check` pass (monorepo pre-commit hook green across all packages).
- Not yet exercised in a simulator.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)