### PR TITLE
feat(mobile): lists (#124)

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -1,15 +1,29 @@
 import { Link } from "expo-router";
-import { View } from "react-native";
+import { ChevronRight, ListChecks, Settings } from "lucide-react-native";
+import { Pressable, View } from "react-native";
 import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
 
 export default function ProfileScreen() {
 	return (
-		<Screen>
-			<View className="flex-1 justify-center gap-3">
-				<Text className="font-display font-semibold text-2xl">Profile</Text>
-				<Link href="/settings" className="font-medium text-accent text-base">
-					Open settings
+		<Screen className="px-0">
+			<View className="px-4 pb-3">
+				<Text className="font-bold font-display text-2xl">Profile</Text>
+			</View>
+			<View className="gap-2 px-4">
+				<Link href="/lists" asChild>
+					<Pressable className="flex-row items-center gap-3 rounded-xl border border-border bg-card p-4">
+						<ListChecks color="#94a3b8" size={20} />
+						<Text className="flex-1 font-medium text-foreground">Lists</Text>
+						<ChevronRight color="#94a3b8" size={18} />
+					</Pressable>
+				</Link>
+				<Link href="/settings" asChild>
+					<Pressable className="flex-row items-center gap-3 rounded-xl border border-border bg-card p-4">
+						<Settings color="#94a3b8" size={20} />
+						<Text className="flex-1 font-medium text-foreground">Settings</Text>
+						<ChevronRight color="#94a3b8" size={18} />
+					</Pressable>
 				</Link>
 			</View>
 		</Screen>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -89,6 +89,8 @@ export default function RootLayout() {
 				<Stack.Screen name="login" />
 				<Stack.Screen name="onboarding" />
 				<Stack.Screen name="settings" options={{ headerShown: true }} />
+				<Stack.Screen name="lists/index" options={{ headerShown: true }} />
+				<Stack.Screen name="lists/[slug]" options={{ headerShown: true }} />
 				<Stack.Screen name="movie/[id]" />
 				<Stack.Screen name="show/[id]/index" />
 				<Stack.Screen name="show/[id]/season/[seasonNumber]/index" />

--- a/apps/mobile/src/app/lists/[slug].tsx
+++ b/apps/mobile/src/app/lists/[slug].tsx
@@ -1,0 +1,180 @@
+import type { MediaInListDto } from "@opnshelf/api";
+import { FlashList } from "@shopify/flash-list";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { Pencil, Trash2, X } from "lucide-react-native";
+import { useState } from "react";
+import { ActivityIndicator, Alert, Pressable, View } from "react-native";
+import { ListEditorSheet } from "@/components/lists/ListEditorSheet";
+import { MediaCard } from "@/components/media/MediaCard";
+import { EmptyState, ErrorState, LoadingState } from "@/components/ui/states";
+import { Text } from "@/components/ui/text";
+import { listItemToMediaCardItem } from "@/lib/list-media";
+import {
+	useDeleteList,
+	useList,
+	useRemoveListItem,
+	useUpdateList,
+} from "@/lib/use-lists";
+import { useTwStyle } from "@/lib/use-tw-style";
+
+function ListItemCard({
+	item,
+	onRemove,
+}: {
+	item: MediaInListDto;
+	onRemove: (item: MediaInListDto) => void;
+}) {
+	return (
+		<View className="flex-1">
+			<MediaCard item={listItemToMediaCardItem(item)} />
+			<Pressable
+				hitSlop={6}
+				onPress={() => onRemove(item)}
+				className="absolute top-1.5 right-1.5 size-7 items-center justify-center rounded-full bg-black/55"
+			>
+				<X color="#ffffff" size={16} strokeWidth={2.5} />
+			</Pressable>
+		</View>
+	);
+}
+
+export default function ListDetailScreen() {
+	const { slug } = useLocalSearchParams<{ slug: string }>();
+	const router = useRouter();
+	const gridStyle = useTwStyle("px-3 pb-12");
+
+	const {
+		list,
+		items,
+		isLoading,
+		isError,
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+	} = useList(slug);
+	const updateList = useUpdateList();
+	const deleteList = useDeleteList();
+	const removeItem = useRemoveListItem(slug);
+
+	const [editorVisible, setEditorVisible] = useState(false);
+
+	const handleRemove = (item: MediaInListDto) => {
+		removeItem.mutate({
+			path: { slug, mediaType: item.mediaType, mediaId: item.mediaId },
+			query: {
+				seasonNumber: item.seasonNumber,
+				episodeNumber: item.episodeNumber,
+			},
+		});
+	};
+
+	const confirmDelete = () => {
+		Alert.alert("Delete list", `Delete “${list?.name ?? "this list"}”?`, [
+			{ text: "Cancel", style: "cancel" },
+			{
+				text: "Delete",
+				style: "destructive",
+				onPress: () =>
+					deleteList.mutate(
+						{ path: { slug } },
+						{ onSuccess: () => router.back() },
+					),
+			},
+		]);
+	};
+
+	const handleSaveEdit = (input: { name: string; description?: string }) => {
+		updateList.mutate({ path: { slug }, body: input });
+		setEditorVisible(false);
+	};
+
+	const canManage = list && !list.isDefault;
+
+	return (
+		<View className="flex-1 bg-background">
+			<Stack.Screen
+				options={{ headerShown: true, title: list?.name ?? "List" }}
+			/>
+
+			{isLoading ? (
+				<LoadingState />
+			) : isError || !list ? (
+				<ErrorState message="Couldn't load this list." />
+			) : (
+				<FlashList
+					data={items}
+					numColumns={3}
+					keyExtractor={(item) => item.id}
+					renderItem={({ item }) => (
+						<View className="flex-1 px-1 pb-3">
+							<ListItemCard item={item} onRemove={handleRemove} />
+						</View>
+					)}
+					contentContainerStyle={gridStyle}
+					showsVerticalScrollIndicator={false}
+					onEndReachedThreshold={0.5}
+					onEndReached={() => {
+						if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+					}}
+					ListHeaderComponent={
+						<View className="gap-3 px-1 pb-4">
+							{list.description ? (
+								<Text className="text-muted-foreground text-sm leading-5">
+									{list.description}
+								</Text>
+							) : null}
+							<Text className="text-muted-foreground text-xs">
+								{list.total} item{list.total === 1 ? "" : "s"}
+							</Text>
+							{canManage ? (
+								<View className="flex-row gap-2">
+									<Pressable
+										onPress={() => setEditorVisible(true)}
+										className="flex-row items-center gap-1.5 rounded-lg border border-border px-3 py-1.5"
+									>
+										<Pencil color="#94a3b8" size={16} />
+										<Text className="font-medium text-foreground text-sm">
+											Edit
+										</Text>
+									</Pressable>
+									<Pressable
+										onPress={confirmDelete}
+										className="flex-row items-center gap-1.5 rounded-lg border border-destructive px-3 py-1.5"
+									>
+										<Trash2 color="#ef4444" size={16} />
+										<Text className="font-medium text-destructive text-sm">
+											Delete
+										</Text>
+									</Pressable>
+								</View>
+							) : null}
+						</View>
+					}
+					ListEmptyComponent={
+						<EmptyState
+							title="Empty list"
+							message="Add movies and shows from their detail screens."
+						/>
+					}
+					ListFooterComponent={
+						isFetchingNextPage ? (
+							<View className="py-6">
+								<ActivityIndicator color="#94a3b8" />
+							</View>
+						) : null
+					}
+				/>
+			)}
+
+			<ListEditorSheet
+				visible={editorVisible}
+				onDismiss={() => setEditorVisible(false)}
+				isEditing
+				initialName={list?.name ?? ""}
+				initialDescription={list?.description ?? ""}
+				onSave={handleSaveEdit}
+				isSaving={updateList.isPending}
+			/>
+		</View>
+	);
+}

--- a/apps/mobile/src/app/lists/index.tsx
+++ b/apps/mobile/src/app/lists/index.tsx
@@ -1,0 +1,100 @@
+import type { ListSummaryDto } from "@opnshelf/api";
+import { FlashList } from "@shopify/flash-list";
+import { Link, Stack } from "expo-router";
+import { ChevronRight, ListPlus, Plus } from "lucide-react-native";
+import { useState } from "react";
+import { Pressable, View } from "react-native";
+import { ListEditorSheet } from "@/components/lists/ListEditorSheet";
+import { EmptyState, ErrorState, LoadingState } from "@/components/ui/states";
+import { Text } from "@/components/ui/text";
+import { useCreateList, useUserLists } from "@/lib/use-lists";
+import { useTwStyle } from "@/lib/use-tw-style";
+
+function ListRow({ list }: { list: ListSummaryDto }) {
+	return (
+		<Link href={`/lists/${list.slug}` as const} asChild>
+			<Pressable className="flex-row items-center gap-3 rounded-xl border border-border bg-card p-4">
+				<View className="min-w-0 flex-1">
+					<Text
+						className="font-semibold text-base text-foreground"
+						numberOfLines={1}
+					>
+						{list.name}
+					</Text>
+					{list.description ? (
+						<Text className="text-muted-foreground text-sm" numberOfLines={1}>
+							{list.description}
+						</Text>
+					) : null}
+					<Text className="mt-0.5 text-muted-foreground text-xs">
+						{list.itemCount} item{list.itemCount === 1 ? "" : "s"}
+					</Text>
+				</View>
+				<ChevronRight color="#94a3b8" size={18} />
+			</Pressable>
+		</Link>
+	);
+}
+
+export default function ListsScreen() {
+	const listStyle = useTwStyle("px-4 pb-8");
+	const { data: lists, isLoading, isError } = useUserLists();
+	const createList = useCreateList();
+	const [editorVisible, setEditorVisible] = useState(false);
+
+	const handleCreate = (input: { name: string; description?: string }) => {
+		createList.mutate({ body: input });
+		setEditorVisible(false);
+	};
+
+	function renderBody() {
+		if (isLoading) return <LoadingState label="Loading your lists…" />;
+		if (isError) return <ErrorState message="Couldn't load your lists." />;
+		if (!lists || lists.length === 0) {
+			return (
+				<EmptyState
+					icon={ListPlus}
+					title="No lists yet"
+					message="Create a list to start organizing movies and shows."
+				/>
+			);
+		}
+		return (
+			<FlashList
+				data={lists}
+				keyExtractor={(item) => item.id}
+				renderItem={({ item }) => (
+					<View className="pb-2">
+						<ListRow list={item} />
+					</View>
+				)}
+				contentContainerStyle={listStyle}
+				showsVerticalScrollIndicator={false}
+			/>
+		);
+	}
+
+	return (
+		<View className="flex-1 bg-background">
+			<Stack.Screen
+				options={{
+					headerShown: true,
+					title: "Lists",
+					headerRight: () => (
+						<Pressable hitSlop={8} onPress={() => setEditorVisible(true)}>
+							<Plus color="#94a3b8" size={22} />
+						</Pressable>
+					),
+				}}
+			/>
+			<View className="flex-1 pt-2">{renderBody()}</View>
+
+			<ListEditorSheet
+				visible={editorVisible}
+				onDismiss={() => setEditorVisible(false)}
+				onSave={handleCreate}
+				isSaving={createList.isPending}
+			/>
+		</View>
+	);
+}

--- a/apps/mobile/src/app/movie/[id].tsx
+++ b/apps/mobile/src/app/movie/[id].tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { AddToListButton } from "@/components/detail/AddToListButton";
 import { CastSection, CrewSection } from "@/components/detail/CreditsSection";
 import { DetailHero } from "@/components/detail/DetailHero";
 import { MediaTrackingActions } from "@/components/detail/MediaTrackingActions";
@@ -55,6 +56,8 @@ export default function MovieDetailScreen() {
 					</DetailHero>
 
 					<MediaTrackingActions mediaType="movie" movieId={id} />
+
+					<AddToListButton mediaType="movie" mediaId={id} />
 
 					<OverviewSection text={data.overview} />
 					<CastSection cast={data.credits?.cast} />

--- a/apps/mobile/src/app/show/[id]/index.tsx
+++ b/apps/mobile/src/app/show/[id]/index.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { AddToListButton } from "@/components/detail/AddToListButton";
 import { CastSection } from "@/components/detail/CreditsSection";
 import { DetailHero } from "@/components/detail/DetailHero";
 import { MediaTrackingActions } from "@/components/detail/MediaTrackingActions";
@@ -63,6 +64,8 @@ export default function ShowDetailScreen() {
 					</DetailHero>
 
 					<MediaTrackingActions mediaType="show" showId={id} />
+
+					<AddToListButton mediaType="show" mediaId={id} />
 
 					<OverviewSection text={data.overview} />
 

--- a/apps/mobile/src/components/detail/AddToListButton.tsx
+++ b/apps/mobile/src/components/detail/AddToListButton.tsx
@@ -1,0 +1,54 @@
+import { ListPlus } from "lucide-react-native";
+import { useState } from "react";
+import { Pressable, View } from "react-native";
+import { AddToListSheet } from "@/components/lists/AddToListSheet";
+import { Text } from "@/components/ui/text";
+import { useAuth } from "@/lib/auth-context";
+import { useListMembership } from "@/lib/use-lists";
+
+/**
+ * "Add to list" action for media detail screens. Opens a sheet of the user's
+ * lists with membership toggles. Shows how many lists the item is in.
+ */
+export function AddToListButton({
+	mediaType,
+	mediaId,
+}: {
+	mediaType: "movie" | "show";
+	mediaId: string;
+}) {
+	const { isAuthenticated } = useAuth();
+	const [sheetVisible, setSheetVisible] = useState(false);
+	const { memberships, isLoading, toggle } = useListMembership({
+		mediaType,
+		mediaId,
+	});
+
+	if (!isAuthenticated) return null;
+
+	const inCount = memberships.filter((l) => l.isInList).length;
+
+	return (
+		<View className="px-4">
+			<Pressable
+				onPress={() => setSheetVisible(true)}
+				className="flex-row items-center justify-center gap-2 rounded-lg border border-border py-3"
+			>
+				<ListPlus color="#94a3b8" size={18} />
+				<Text className="font-semibold text-foreground">
+					{inCount > 0
+						? `In ${inCount} list${inCount === 1 ? "" : "s"}`
+						: "Add to list"}
+				</Text>
+			</Pressable>
+
+			<AddToListSheet
+				visible={sheetVisible}
+				onDismiss={() => setSheetVisible(false)}
+				memberships={memberships}
+				isLoading={isLoading}
+				onToggle={toggle}
+			/>
+		</View>
+	);
+}

--- a/apps/mobile/src/components/lists/AddToListSheet.tsx
+++ b/apps/mobile/src/components/lists/AddToListSheet.tsx
@@ -1,0 +1,86 @@
+import type { ListsForItemDto } from "@opnshelf/api";
+import { Check, X } from "lucide-react-native";
+import { Modal, Pressable, ScrollView, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { cn } from "@/lib/cn";
+
+/**
+ * Bottom sheet listing the user's lists with membership checkmarks for one
+ * media item. Tapping a row toggles the item in/out of that list (optimistic,
+ * handled by the parent's `useListMembership`).
+ */
+export function AddToListSheet({
+	visible,
+	onDismiss,
+	memberships,
+	isLoading,
+	onToggle,
+}: {
+	visible: boolean;
+	onDismiss: () => void;
+	memberships: ListsForItemDto[];
+	isLoading?: boolean;
+	onToggle: (slug: string, isInList: boolean) => void;
+}) {
+	return (
+		<Modal
+			visible={visible}
+			animationType="slide"
+			transparent
+			onRequestClose={onDismiss}
+		>
+			<View className="flex-1 justify-end">
+				<Pressable className="flex-1" onPress={onDismiss} />
+				<View className="max-h-[70%] gap-3 rounded-t-2xl border border-border bg-card p-5">
+					<View className="flex-row items-center justify-between">
+						<Text className="font-bold font-display text-foreground text-lg">
+							Add to list
+						</Text>
+						<Pressable hitSlop={8} onPress={onDismiss}>
+							<X color="#94a3b8" size={22} />
+						</Pressable>
+					</View>
+
+					{isLoading ? (
+						<Text className="py-4 text-muted-foreground text-sm">Loading…</Text>
+					) : memberships.length === 0 ? (
+						<Text className="py-4 text-muted-foreground text-sm">
+							You have no lists yet. Create one from the Lists screen.
+						</Text>
+					) : (
+						<ScrollView showsVerticalScrollIndicator={false}>
+							<View className="gap-2">
+								{memberships.map((list) => (
+									<Pressable
+										key={list.listSlug}
+										onPress={() => onToggle(list.listSlug, list.isInList)}
+										className="flex-row items-center gap-3 rounded-lg border border-border p-3"
+									>
+										<View
+											className={cn(
+												"size-6 items-center justify-center rounded-md border",
+												list.isInList
+													? "border-primary bg-primary"
+													: "border-border",
+											)}
+										>
+											{list.isInList ? (
+												<Check color="#3f2e00" size={16} strokeWidth={3} />
+											) : null}
+										</View>
+										<Text
+											className="flex-1 font-medium text-foreground text-sm"
+											numberOfLines={1}
+										>
+											{list.listName}
+										</Text>
+									</Pressable>
+								))}
+							</View>
+						</ScrollView>
+					)}
+				</View>
+			</View>
+		</Modal>
+	);
+}

--- a/apps/mobile/src/components/lists/ListEditorSheet.tsx
+++ b/apps/mobile/src/components/lists/ListEditorSheet.tsx
@@ -1,0 +1,113 @@
+import { X } from "lucide-react-native";
+import { useEffect, useState } from "react";
+import {
+	KeyboardAvoidingView,
+	Modal,
+	Platform,
+	Pressable,
+	TextInput,
+	View,
+} from "react-native";
+import { Text } from "@/components/ui/text";
+
+interface ListEditorSheetProps {
+	visible: boolean;
+	onDismiss: () => void;
+	isEditing?: boolean;
+	initialName?: string;
+	initialDescription?: string;
+	onSave: (input: { name: string; description?: string }) => void;
+	isSaving?: boolean;
+}
+
+/**
+ * Bottom sheet for creating or editing a list (name + optional description).
+ * Sibling of the review/note editor sheets. A list requires a name.
+ */
+export function ListEditorSheet({
+	visible,
+	onDismiss,
+	isEditing = false,
+	initialName = "",
+	initialDescription = "",
+	onSave,
+	isSaving = false,
+}: ListEditorSheetProps) {
+	const [name, setName] = useState(initialName);
+	const [description, setDescription] = useState(initialDescription);
+
+	useEffect(() => {
+		if (visible) {
+			setName(initialName);
+			setDescription(initialDescription);
+		}
+	}, [visible, initialName, initialDescription]);
+
+	const canSave = name.trim().length > 0 && !isSaving;
+
+	return (
+		<Modal
+			visible={visible}
+			animationType="slide"
+			transparent
+			onRequestClose={onDismiss}
+		>
+			<KeyboardAvoidingView
+				behavior={Platform.OS === "ios" ? "padding" : undefined}
+				className="flex-1 justify-end"
+			>
+				<Pressable className="flex-1" onPress={onDismiss} />
+				<View className="gap-4 rounded-t-2xl border border-border bg-card p-5">
+					<View className="flex-row items-center justify-between">
+						<Text className="font-bold font-display text-foreground text-lg">
+							{isEditing ? "Edit list" : "New list"}
+						</Text>
+						<Pressable hitSlop={8} onPress={onDismiss}>
+							<X color="#94a3b8" size={22} />
+						</Pressable>
+					</View>
+
+					<TextInput
+						value={name}
+						onChangeText={setName}
+						placeholder="List name"
+						placeholderTextColor="#94a3b8"
+						maxLength={200}
+						className="rounded-lg border border-border bg-background-subtle p-3 font-sans text-base text-foreground"
+					/>
+
+					<TextInput
+						value={description}
+						onChangeText={setDescription}
+						placeholder="Description (optional)"
+						placeholderTextColor="#94a3b8"
+						multiline
+						textAlignVertical="top"
+						maxLength={2000}
+						className="min-h-24 rounded-lg border border-border bg-background-subtle p-3 font-sans text-base text-foreground"
+					/>
+
+					<Pressable
+						onPress={() =>
+							onSave({
+								name: name.trim(),
+								description: description.trim() || undefined,
+							})
+						}
+						disabled={!canSave}
+						className="items-center rounded-lg bg-primary py-3"
+						style={{ opacity: canSave ? 1 : 0.5 }}
+					>
+						<Text className="font-semibold text-primary-foreground">
+							{isSaving
+								? "Saving…"
+								: isEditing
+									? "Save changes"
+									: "Create list"}
+						</Text>
+					</Pressable>
+				</View>
+			</KeyboardAvoidingView>
+		</Modal>
+	);
+}

--- a/apps/mobile/src/lib/list-media.ts
+++ b/apps/mobile/src/lib/list-media.ts
@@ -1,0 +1,53 @@
+import type { MediaInListDto } from "@opnshelf/api";
+import type { MediaCardItem } from "@/components/media/MediaCard";
+
+/**
+ * `MediaInListDto.media` arrives as loosely-typed JSON (TMDB shape). These
+ * helpers read the fields the mobile cards need defensively, accepting both
+ * snake_case (TMDB) and camelCase (backend) variants, mirroring the web list
+ * page helpers.
+ */
+type Media = Record<string, unknown>;
+
+function str(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function num(value: unknown): number | undefined {
+	return typeof value === "number" ? value : undefined;
+}
+
+export function getMediaTitle(media: Media): string {
+	return str(media.title) ?? str(media.name) ?? "Untitled";
+}
+
+export function getMediaPosterPath(media: Media): string | undefined {
+	return str(media.poster_path) ?? str(media.posterPath);
+}
+
+export function getMediaYear(media: Media): string | undefined {
+	const date = str(media.release_date) ?? str(media.first_air_date);
+	if (date) {
+		const year = new Date(date).getFullYear();
+		if (!Number.isNaN(year)) return String(year);
+	}
+	const releaseYear = num(media.releaseYear) ?? num(media.firstAirYear);
+	return releaseYear ? String(releaseYear) : undefined;
+}
+
+export function getMediaRating(media: Media): number | undefined {
+	return num(media.vote_average) ?? num(media.voteAverage);
+}
+
+/** Map a list item to a `MediaCard` item (season/episode entries point at the show). */
+export function listItemToMediaCardItem(item: MediaInListDto): MediaCardItem {
+	const media = (item.media ?? {}) as Media;
+	return {
+		id: Number(item.mediaId),
+		type: item.mediaType === "movie" ? "movie" : "show",
+		title: getMediaTitle(media),
+		posterPath: getMediaPosterPath(media),
+		year: getMediaYear(media),
+		rating: getMediaRating(media),
+	};
+}

--- a/apps/mobile/src/lib/use-lists.ts
+++ b/apps/mobile/src/lib/use-lists.ts
@@ -1,0 +1,269 @@
+import {
+	type ListsForItemDto,
+	listsControllerAddItemToListMutation,
+	listsControllerCreateListMutation,
+	listsControllerDeleteListMutation,
+	listsControllerGetListInfiniteOptions,
+	listsControllerGetListQueryKey,
+	listsControllerGetListsForItemOptions,
+	listsControllerGetListsForItemQueryKey,
+	listsControllerGetUserListsOptions,
+	listsControllerGetUserListsQueryKey,
+	listsControllerRemoveItemFromListMutation,
+	listsControllerUpdateListMutation,
+} from "@opnshelf/api";
+import {
+	useInfiniteQuery,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import * as Haptics from "expo-haptics";
+import { useToast } from "@/components/ui/toast";
+import { useAuth } from "@/lib/auth-context";
+
+function errorMessage(error: unknown, fallback: string) {
+	return error instanceof Error ? error.message : fallback;
+}
+
+/** All of the current user's lists. */
+export function useUserLists() {
+	const { isAuthenticated } = useAuth();
+	return useQuery({
+		...listsControllerGetUserListsOptions(),
+		enabled: isAuthenticated,
+	});
+}
+
+/** A single list with its items (infinite). */
+export function useList(slug: string, pageSize = 30) {
+	const query = useInfiniteQuery({
+		...listsControllerGetListInfiniteOptions({
+			path: { slug },
+			query: { pageSize },
+		}),
+		enabled: !!slug,
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) =>
+			lastPage.hasNextPage ? lastPage.page + 1 : undefined,
+	});
+	const first = query.data?.pages[0];
+	return {
+		list: first,
+		items: query.data?.pages.flatMap((p) => p.items) ?? [],
+		isLoading: query.isLoading,
+		isError: query.isError,
+		fetchNextPage: query.fetchNextPage,
+		hasNextPage: query.hasNextPage,
+		isFetchingNextPage: query.isFetchingNextPage,
+	};
+}
+
+/** Create a list. */
+export function useCreateList() {
+	const queryClient = useQueryClient();
+	const toast = useToast();
+	return useMutation({
+		mutationKey: ["lists", "create"],
+		...listsControllerCreateListMutation(),
+		onSuccess: () => {
+			toast.success("List created");
+			queryClient.invalidateQueries({
+				queryKey: listsControllerGetUserListsQueryKey(),
+			});
+		},
+		onError: (error) =>
+			toast.error(errorMessage(error, "Failed to create list")),
+	});
+}
+
+/** Update a list's name/description. */
+export function useUpdateList() {
+	const queryClient = useQueryClient();
+	const toast = useToast();
+	return useMutation({
+		mutationKey: ["lists", "update"],
+		...listsControllerUpdateListMutation(),
+		onSuccess: (_data, variables) => {
+			toast.success("List updated");
+			queryClient.invalidateQueries({
+				queryKey: listsControllerGetUserListsQueryKey(),
+			});
+			queryClient.invalidateQueries({
+				queryKey: listsControllerGetListQueryKey({
+					path: { slug: variables.path.slug },
+				}),
+			});
+		},
+		onError: (error) =>
+			toast.error(errorMessage(error, "Failed to update list")),
+	});
+}
+
+/** Delete a list. */
+export function useDeleteList() {
+	const queryClient = useQueryClient();
+	const toast = useToast();
+	return useMutation({
+		mutationKey: ["lists", "delete"],
+		...listsControllerDeleteListMutation(),
+		onSuccess: () => {
+			toast.success("List deleted");
+			queryClient.invalidateQueries({
+				queryKey: listsControllerGetUserListsQueryKey(),
+			});
+		},
+		onError: (error) =>
+			toast.error(errorMessage(error, "Failed to delete list")),
+	});
+}
+
+/** Remove an item from a specific list (used on the list detail screen). */
+export function useRemoveListItem(slug: string) {
+	const queryClient = useQueryClient();
+	const toast = useToast();
+	return useMutation({
+		mutationKey: ["lists", slug, "removeItem"],
+		...listsControllerRemoveItemFromListMutation(),
+		onSuccess: () => {
+			void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+				() => {},
+			);
+			toast.success("Removed from list");
+			queryClient.invalidateQueries({
+				queryKey: listsControllerGetListQueryKey({ path: { slug } }),
+			});
+			queryClient.invalidateQueries({
+				queryKey: listsControllerGetUserListsQueryKey(),
+			});
+		},
+		onError: (error) =>
+			toast.error(errorMessage(error, "Failed to remove from list")),
+	});
+}
+
+interface ListMembershipTarget {
+	mediaType: "movie" | "show";
+	mediaId: string;
+	seasonNumber?: number;
+	episodeNumber?: number;
+}
+
+/**
+ * Which of the user's lists contain a media item, plus an optimistic toggle to
+ * add/remove it. Mirrors the web `useListActions` — patches `isInList` in the
+ * for-item cache immediately, rolls back on error, and reconciles the for-item
+ * + user-lists queries on settle.
+ */
+export function useListMembership(target: ListMembershipTarget) {
+	const { isAuthenticated } = useAuth();
+	const queryClient = useQueryClient();
+	const toast = useToast();
+
+	const resolvedMediaType =
+		target.episodeNumber != null
+			? "episode"
+			: target.seasonNumber != null
+				? "season"
+				: target.mediaType;
+
+	const listsForItemKey = listsControllerGetListsForItemQueryKey({
+		path: { mediaType: resolvedMediaType, mediaId: target.mediaId },
+		query: {
+			seasonNumber: target.seasonNumber,
+			episodeNumber: target.episodeNumber,
+		},
+	});
+	const userListsKey = listsControllerGetUserListsQueryKey();
+
+	const membershipQuery = useQuery({
+		...listsControllerGetListsForItemOptions({
+			path: { mediaType: resolvedMediaType, mediaId: target.mediaId },
+			query: {
+				seasonNumber: target.seasonNumber,
+				episodeNumber: target.episodeNumber,
+			},
+		}),
+		enabled: isAuthenticated && !!target.mediaId,
+	});
+
+	const patchMembership = (slug: string, isInList: boolean) => {
+		queryClient.setQueryData<ListsForItemDto[]>(listsForItemKey, (old) =>
+			Array.isArray(old)
+				? old.map((l) => (l.listSlug === slug ? { ...l, isInList } : l))
+				: old,
+		);
+	};
+
+	const settle = () => {
+		queryClient.invalidateQueries({ queryKey: listsForItemKey });
+		queryClient.invalidateQueries({ queryKey: userListsKey });
+	};
+
+	const addMutation = useMutation({
+		mutationKey: ["lists", "addItem", resolvedMediaType, target.mediaId],
+		...listsControllerAddItemToListMutation(),
+		onMutate: async (variables) => {
+			await queryClient.cancelQueries({ queryKey: listsForItemKey });
+			const prev = queryClient.getQueryData<ListsForItemDto[]>(listsForItemKey);
+			patchMembership(variables.path.slug, true);
+			return { prev };
+		},
+		onError: (error, _vars, context) => {
+			if (context?.prev !== undefined) {
+				queryClient.setQueryData(listsForItemKey, context.prev);
+			}
+			toast.error(errorMessage(error, "Failed to add to list"));
+		},
+		onSettled: settle,
+	});
+
+	const removeMutation = useMutation({
+		mutationKey: ["lists", "removeItem", resolvedMediaType, target.mediaId],
+		...listsControllerRemoveItemFromListMutation(),
+		onMutate: async (variables) => {
+			await queryClient.cancelQueries({ queryKey: listsForItemKey });
+			const prev = queryClient.getQueryData<ListsForItemDto[]>(listsForItemKey);
+			patchMembership(variables.path.slug, false);
+			return { prev };
+		},
+		onError: (error, _vars, context) => {
+			if (context?.prev !== undefined) {
+				queryClient.setQueryData(listsForItemKey, context.prev);
+			}
+			toast.error(errorMessage(error, "Failed to remove from list"));
+		},
+		onSettled: settle,
+	});
+
+	const toggle = (slug: string, isInList: boolean) => {
+		if (!isAuthenticated) return;
+		void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+		if (isInList) {
+			removeMutation.mutate({
+				path: { slug, mediaType: resolvedMediaType, mediaId: target.mediaId },
+				query: {
+					seasonNumber: target.seasonNumber,
+					episodeNumber: target.episodeNumber,
+				},
+			});
+		} else {
+			addMutation.mutate({
+				path: { slug },
+				body: {
+					mediaType: resolvedMediaType,
+					mediaId: target.mediaId,
+					seasonNumber: target.seasonNumber,
+					episodeNumber: target.episodeNumber,
+				},
+			});
+		}
+	};
+
+	return {
+		memberships: membershipQuery.data ?? [],
+		isLoading: membershipQuery.isLoading,
+		toggle,
+		isPending: addMutation.isPending || removeMutation.isPending,
+	};
+}


### PR DESCRIPTION
Adds lists to mobile. Part of the deferred Mobile rework work (#89).

## What
- **Lists screen** (`/lists`, from the Profile tab): the user's lists, with a create sheet (name + optional description).
- **List detail** (`/lists/[slug]`): infinite item grid, inline **Edit** / **Delete** for non-default lists, and a per-item remove (×) overlay.
- **Add to list** on movie/show detail: opens a membership sheet to toggle the item in/out of each list.

## How
- `use-lists`: `useUserLists`, `useList` (infinite items), `useCreateList`/`useUpdateList`/`useDeleteList`, a per-list `useRemoveListItem`, and `useListMembership` — an optimistic add/remove toggle mirroring the web `useListActions` (patch `isInList` immediately, roll back on error, reconcile the for-item + user-lists queries on settle).
- List item media arrives as loosely-typed JSON; `list-media.ts` reads title/poster/year/rating defensively (snake_case + camelCase) into a `MediaCard` item, mirroring the web list helpers.

## Verification
- `tsc --noEmit` and `biome check` pass (monorepo pre-commit hook green across all packages).
- Not yet exercised in a simulator.

## Note
Touches `profile.tsx` (adds a Lists entry) — overlaps with the Social PR (#137), which adds a Friends entry to the same menu. Trivial merge either way; whichever lands first, I'll rebase the other to include both.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)