### PR TITLE
feat(mobile): Trakt import (#129)

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -89,6 +89,7 @@ export default function RootLayout() {
 				<Stack.Screen name="login" />
 				<Stack.Screen name="onboarding" />
 				<Stack.Screen name="settings" options={{ headerShown: true }} />
+				<Stack.Screen name="trakt-import" options={{ headerShown: true }} />
 				<Stack.Screen name="movie/[id]" />
 				<Stack.Screen name="show/[id]/index" />
 				<Stack.Screen name="show/[id]/season/[seasonNumber]/index" />

--- a/apps/mobile/src/app/settings.tsx
+++ b/apps/mobile/src/app/settings.tsx
@@ -1,4 +1,5 @@
-import { Stack } from "expo-router";
+import { Link, Stack } from "expo-router";
+import { ChevronRight, Download } from "lucide-react-native";
 import { useState } from "react";
 import { ActivityIndicator, Pressable, View } from "react-native";
 import { Screen } from "@/components/ui/screen";
@@ -36,6 +37,16 @@ export default function SettingsScreen() {
 							</Text>
 						</View>
 					)}
+
+					<Link href="/trakt-import" asChild>
+						<Pressable className="flex-row items-center gap-3 rounded-xl border border-border bg-card p-4">
+							<Download color="#94a3b8" size={20} />
+							<Text className="flex-1 font-medium text-foreground">
+								Import from Trakt
+							</Text>
+							<ChevronRight color="#94a3b8" size={18} />
+						</Pressable>
+					</Link>
 
 					<Pressable
 						disabled={isSigningOut}

--- a/apps/mobile/src/app/trakt-import.tsx
+++ b/apps/mobile/src/app/trakt-import.tsx
@@ -1,0 +1,138 @@
+import { isActiveTraktImportStatus } from "@opnshelf/api";
+import { Stack } from "expo-router";
+import { Download, Film, Tv } from "lucide-react-native";
+import { useState } from "react";
+import { Pressable, ScrollView, TextInput, View } from "react-native";
+import { TraktImportBanner } from "@/components/trakt/TraktImportBanner";
+import { Text } from "@/components/ui/text";
+import { useTraktImport } from "@/lib/use-trakt-import";
+
+export default function TraktImportScreen() {
+	const [username, setUsername] = useState("");
+	const { currentJob, fetchPreview, startImport } = useTraktImport();
+
+	const preview = fetchPreview.data;
+	const trimmed = username.trim();
+	const importActive = currentJob
+		? isActiveTraktImportStatus(currentJob.status)
+		: false;
+
+	const handleFetch = () => {
+		if (!trimmed) return;
+		fetchPreview.mutate({ body: { username: trimmed } });
+	};
+
+	const handleStart = () => {
+		if (!trimmed) return;
+		startImport.mutate({ body: { username: trimmed } });
+	};
+
+	return (
+		<View className="flex-1 bg-background">
+			<Stack.Screen
+				options={{ headerShown: true, title: "Import from Trakt" }}
+			/>
+			<ScrollView
+				className="flex-1"
+				contentContainerClassName="gap-4 px-4 py-4 pb-12"
+				keyboardShouldPersistTaps="handled"
+				showsVerticalScrollIndicator={false}
+			>
+				<Text className="text-muted-foreground text-sm leading-5">
+					Enter a public Trakt username. We’ll fetch that profile’s watch
+					history and import it in the background — no CSV needed.
+				</Text>
+
+				<View className="gap-2">
+					<Text className="font-medium text-foreground text-sm">
+						Trakt username
+					</Text>
+					<TextInput
+						value={username}
+						onChangeText={setUsername}
+						placeholder="your-trakt-username"
+						placeholderTextColor="#94a3b8"
+						autoCapitalize="none"
+						autoCorrect={false}
+						returnKeyType="search"
+						onSubmitEditing={handleFetch}
+						className="rounded-lg border border-border bg-card px-3 py-3 font-sans text-base text-foreground"
+					/>
+					<Pressable
+						onPress={handleFetch}
+						disabled={!trimmed || fetchPreview.isPending}
+						className="flex-row items-center justify-center gap-2 rounded-lg border border-border py-3"
+						style={{ opacity: !trimmed || fetchPreview.isPending ? 0.5 : 1 }}
+					>
+						<Text className="font-semibold text-foreground">
+							{fetchPreview.isPending ? "Fetching…" : "Fetch history"}
+						</Text>
+					</Pressable>
+				</View>
+
+				{preview ? (
+					<View className="gap-3 rounded-xl border border-border bg-card p-4">
+						<View>
+							<Text className="font-semibold text-base text-foreground">
+								{preview.profile.name || preview.profile.username}
+							</Text>
+							<Text className="text-muted-foreground text-xs">
+								@{preview.profile.username}
+							</Text>
+						</View>
+						<Text className="text-muted-foreground text-sm">
+							{preview.importableCount} importable item
+							{preview.importableCount === 1 ? "" : "s"} found in the recent
+							history preview.
+						</Text>
+
+						{preview.previewItems.length > 0 ? (
+							<View className="gap-2">
+								{preview.previewItems.slice(0, 6).map((item) => (
+									<View
+										key={`${item.type}-${item.title}-${item.watchedAt}`}
+										className="flex-row items-center gap-2"
+									>
+										{item.type === "movie" ? (
+											<Film color="#94a3b8" size={14} />
+										) : (
+											<Tv color="#94a3b8" size={14} />
+										)}
+										<Text
+											className="flex-1 text-foreground text-sm"
+											numberOfLines={1}
+										>
+											{item.title}
+											{item.subtitle ? (
+												<Text className="text-muted-foreground">
+													{"  "}
+													{item.subtitle}
+												</Text>
+											) : null}
+										</Text>
+									</View>
+								))}
+							</View>
+						) : null}
+
+						<Pressable
+							onPress={handleStart}
+							disabled={startImport.isPending || importActive}
+							className="flex-row items-center justify-center gap-2 rounded-lg bg-primary py-3"
+							style={{
+								opacity: startImport.isPending || importActive ? 0.6 : 1,
+							}}
+						>
+							<Download color="#3f2e00" size={18} />
+							<Text className="font-semibold text-primary-foreground">
+								{importActive ? "Import in progress…" : "Start import"}
+							</Text>
+						</Pressable>
+					</View>
+				) : null}
+
+				{currentJob ? <TraktImportBanner job={currentJob} /> : null}
+			</ScrollView>
+		</View>
+	);
+}

--- a/apps/mobile/src/components/trakt/TraktImportBanner.tsx
+++ b/apps/mobile/src/components/trakt/TraktImportBanner.tsx
@@ -1,0 +1,57 @@
+import {
+	getTraktImportStatusMessage,
+	getTraktImportStatusProgress,
+	isTerminalTraktImportStatus,
+	type TraktImportJobDto,
+} from "@opnshelf/api";
+import { CheckCircle2, Loader2, TriangleAlert } from "lucide-react-native";
+import { View } from "react-native";
+import { Text } from "@/components/ui/text";
+
+/**
+ * Status banner for an in-flight or finished Trakt import job: a progress bar
+ * (when known) plus a human-readable status message. Uses the shared
+ * `@opnshelf/api` status helpers so wording matches web.
+ */
+export function TraktImportBanner({ job }: { job: TraktImportJobDto }) {
+	const progress = getTraktImportStatusProgress(job);
+	const message = getTraktImportStatusMessage(job);
+	const isDone = isTerminalTraktImportStatus(job.status);
+	const isFailed = job.status === "failed";
+
+	const Icon = isFailed ? TriangleAlert : isDone ? CheckCircle2 : Loader2;
+	const iconColor = isFailed ? "#ef4444" : isDone ? "#22c55e" : "#f3bc00";
+
+	return (
+		<View className="gap-3 rounded-xl border border-border bg-card p-4">
+			<View className="flex-row items-center gap-2">
+				<Icon color={iconColor} size={18} />
+				<Text className="font-semibold text-foreground text-sm">
+					{job.status === "completed"
+						? "Import complete"
+						: job.status === "failed"
+							? "Import failed"
+							: "Importing from Trakt"}
+				</Text>
+			</View>
+
+			{progress !== null ? (
+				<View className="flex-row items-center gap-2">
+					<View className="h-1.5 flex-1 overflow-hidden rounded-full bg-background-subtle">
+						<View
+							className="h-full rounded-full bg-primary"
+							style={{ width: `${progress}%` }}
+						/>
+					</View>
+					<Text className="text-muted-foreground text-xs">{progress}%</Text>
+				</View>
+			) : null}
+
+			{message ? (
+				<Text className="text-muted-foreground text-sm leading-5">
+					{message}
+				</Text>
+			) : null}
+		</View>
+	);
+}

--- a/apps/mobile/src/lib/use-trakt-import.ts
+++ b/apps/mobile/src/lib/use-trakt-import.ts
@@ -1,0 +1,67 @@
+import {
+	isActiveTraktImportStatus,
+	usersControllerFetchMyTraktPublicHistoryMutation,
+	usersControllerGetMyCurrentTraktImportOptions,
+	usersControllerGetMyCurrentTraktImportQueryKey,
+	usersControllerStartMyTraktImportMutation,
+} from "@opnshelf/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@/components/ui/toast";
+import { useAuth } from "@/lib/auth-context";
+
+function errorMessage(error: unknown, fallback: string) {
+	return error instanceof Error ? error.message : fallback;
+}
+
+/**
+ * Trakt public-history import: fetch a preview for a username, start the
+ * server-side import job, and poll its status while active. Mirrors the web
+ * onboarding Trakt step over the shared `@opnshelf/api` procedures. (The
+ * backend has no CSV import; it fetches and TMDB-resolves a public Trakt
+ * profile server-side.)
+ */
+export function useTraktImport() {
+	const { isAuthenticated } = useAuth();
+	const queryClient = useQueryClient();
+	const toast = useToast();
+
+	const currentQuery = useQuery({
+		...usersControllerGetMyCurrentTraktImportOptions(),
+		enabled: isAuthenticated,
+		refetchInterval: (query) => {
+			const status = query.state.data?.status;
+			return status && isActiveTraktImportStatus(status) ? 3000 : false;
+		},
+	});
+
+	const fetchPreview = useMutation({
+		mutationKey: ["trakt", "fetchPreview"],
+		...usersControllerFetchMyTraktPublicHistoryMutation(),
+		onError: (error) =>
+			toast.error(
+				errorMessage(
+					error,
+					"Couldn't fetch that Trakt profile. Check the username and try again.",
+				),
+			),
+	});
+
+	const startImport = useMutation({
+		mutationKey: ["trakt", "startImport"],
+		...usersControllerStartMyTraktImportMutation(),
+		onSuccess: () => {
+			toast.success("Import started");
+			queryClient.invalidateQueries({
+				queryKey: usersControllerGetMyCurrentTraktImportQueryKey(),
+			});
+		},
+		onError: (error) =>
+			toast.error(errorMessage(error, "Failed to start import")),
+	});
+
+	return {
+		currentJob: currentQuery.data ?? null,
+		fetchPreview,
+		startImport,
+	};
+}


### PR DESCRIPTION
Adds Trakt import to mobile. Part of the deferred Mobile rework work (#89).

## Scope decision (please read)
Issue #129 asks for **CSV import** (papaparse + document picker). That can't work against the current backend: the only Trakt import endpoint fetches and TMDB-resolves a **public profile** server-side, and `POST /users/me/import/history` requires `NormalizedImportItemDto` with **pre-resolved TMDB ids** — which a Trakt CSV export (Trakt/IMDb ids + title/year) doesn't carry. Resolving IDs client-side isn't viable on mobile.

So this ports the **public-username flow** the web app actually uses. A backend CSV-import endpoint (that resolves Trakt/IMDb→TMDB) is needed for the literal CSV ask — I'll file that as a follow-up.

## What
- **Trakt import screen** (`/trakt-import`, from Settings): enter a Trakt username → fetch a history **preview** (profile, importable count, recent items) → **Start import**.
- **Status banner**: live progress bar + status message, polling the current job every 3s while active, using the shared `@opnshelf/api` Trakt status helpers (same wording as web).

## Verification
- `tsc --noEmit` and `biome check` pass (monorepo pre-commit hook green across all packages).
- Not yet exercised in a simulator.

Refs #129 (closing deferred to the CSV follow-up, since the literal CSV path isn't delivered here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)